### PR TITLE
계산기 [STEP 2] is, june

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
 		BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */; };
 		BFEE745A2977D1DE00ACB03E /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE74592977D1DE00ACB03E /* ExpressionParser.swift */; };
+		BFF4D345297A288A00A48817 /* CalculatorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF4D344297A288A00A48817 /* CalculatorModelTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -51,6 +52,7 @@
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		BFEE74592977D1DE00ACB03E /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
+		BFF4D344297A288A00A48817 /* CalculatorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorModelTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				BF283A822978D701005DD048 /* StringExtensionTests.swift */,
 				B21D83E02976868700E27BCA /* FormulaTests.swift */,
 				40A385A6297934780030787D /* Extensions.swift */,
+				BFF4D344297A288A00A48817 /* CalculatorModelTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -295,6 +298,7 @@
 				40A49F16297A1DA000208614 /* FormulaTests.swift in Sources */,
 				40A385A7297934780030787D /* Extensions.swift in Sources */,
 				B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */,
+				BFF4D345297A288A00A48817 /* CalculatorModelTests.swift in Sources */,
 				BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */,
 				BF283A832978D701005DD048 /* StringExtensionTests.swift in Sources */,
 			);

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,12 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		40A385A7297934780030787D /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A385A6297934780030787D /* Extensions.swift */; };
+		40A49F16297A1DA000208614 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
 		B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */; };
 		B21D83DD29763B2200E27BCA /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83DC29763B2200E27BCA /* Operator.swift */; };
-		B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
 		B21D83E3297687ED00E27BCA /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E2297687ED00E27BCA /* Formula.swift */; };
 		BF283A7F2978D58E005DD048 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF283A7E2978D58E005DD048 /* String+Extension.swift */; };
-		BF283A832978D701005DD048 /* ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF283A822978D701005DD048 /* ExtensionTests.swift */; };
+		BF283A832978D701005DD048 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF283A822978D701005DD048 /* StringExtensionTests.swift */; };
 		BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */; };
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
@@ -37,13 +38,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		40A385A6297934780030787D /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		B21D83D32976311000E27BCA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		B21D83DC29763B2200E27BCA /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		B21D83E02976868700E27BCA /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		B21D83E2297687ED00E27BCA /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		BF283A7E2978D58E005DD048 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
-		BF283A822978D701005DD048 /* ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionTests.swift; sourceTree = "<group>"; };
+		BF283A822978D701005DD048 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
@@ -81,9 +83,10 @@
 			isa = PBXGroup;
 			children = (
 				B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */,
-				B21D83E02976868700E27BCA /* FormulaTests.swift */,
 				BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */,
-				BF283A822978D701005DD048 /* ExtensionTests.swift */,
+				BF283A822978D701005DD048 /* StringExtensionTests.swift */,
+				B21D83E02976868700E27BCA /* FormulaTests.swift */,
+				40A385A6297934780030787D /* Extensions.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -289,10 +292,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */,
+				40A49F16297A1DA000208614 /* FormulaTests.swift in Sources */,
+				40A385A7297934780030787D /* Extensions.swift in Sources */,
 				B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */,
 				BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */,
-				BF283A832978D701005DD048 /* ExtensionTests.swift in Sources */,
+				BF283A832978D701005DD048 /* StringExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		407CCAC2297A521300E73142 /* CalculatorItemQueueProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407CCAC1297A521300E73142 /* CalculatorItemQueueProtocol.swift */; };
 		40A385A7297934780030787D /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A385A6297934780030787D /* Extensions.swift */; };
 		40A49F16297A1DA000208614 /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
 		B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		407CCAC1297A521300E73142 /* CalculatorItemQueueProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueProtocol.swift; sourceTree = "<group>"; };
 		40A385A6297934780030787D /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		B21D83D32976311000E27BCA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				BF9AE30429765ABB0021D14E /* CalculateItem.swift */,
+				407CCAC1297A521300E73142 /* CalculatorItemQueueProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				B21D83E3297687ED00E27BCA /* Formula.swift in Sources */,
 				BF283A7F2978D58E005DD048 /* String+Extension.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
+				407CCAC2297A521300E73142 /* CalculatorItemQueueProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */; };
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
+		BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -41,6 +42,7 @@
 		BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
+		BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +76,7 @@
 			children = (
 				B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */,
 				B21D83E02976868700E27BCA /* FormulaTests.swift */,
+				BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -279,6 +282,7 @@
 			files = (
 				B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */,
 				B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */,
+				BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */; };
 		B21D83DD29763B2200E27BCA /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83DC29763B2200E27BCA /* Operator.swift */; };
 		B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
+		B21D83E3297687ED00E27BCA /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E2297687ED00E27BCA /* Formula.swift */; };
 		BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */; };
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
@@ -36,6 +37,7 @@
 		B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		B21D83DC29763B2200E27BCA /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		B21D83E02976868700E27BCA /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
+		B21D83E2297687ED00E27BCA /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
 		BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			children = (
 				BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */,
 				B21D83DC29763B2200E27BCA /* Operator.swift */,
+				B21D83E2297687ED00E27BCA /* Formula.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */,
 				BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */,
 				BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */,
+				B21D83E3297687ED00E27BCA /* Formula.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,8 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B21D83D62976311000E27BCA /* CalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83D52976311000E27BCA /* CalculatorTests.swift */; };
+		B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */; };
 		B21D83DD29763B2200E27BCA /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83DC29763B2200E27BCA /* Operator.swift */; };
+		B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
 		BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */; };
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
@@ -32,8 +33,9 @@
 
 /* Begin PBXFileReference section */
 		B21D83D32976311000E27BCA /* CalculatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		B21D83D52976311000E27BCA /* CalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorTests.swift; sourceTree = "<group>"; };
+		B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueueTests.swift; sourceTree = "<group>"; };
 		B21D83DC29763B2200E27BCA /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		B21D83E02976868700E27BCA /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
@@ -68,7 +70,8 @@
 		B21D83D42976311000E27BCA /* CalculatorTests */ = {
 			isa = PBXGroup;
 			children = (
-				B21D83D52976311000E27BCA /* CalculatorTests.swift */,
+				B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */,
+				B21D83E02976868700E27BCA /* FormulaTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -271,7 +274,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B21D83D62976311000E27BCA /* CalculatorTests.swift in Sources */,
+				B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */,
+				B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
 		BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */; };
+		BFEE745A2977D1DE00ACB03E /* ExpressionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEE74592977D1DE00ACB03E /* ExpressionParser.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -43,6 +44,7 @@
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
 		BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParserTests.swift; sourceTree = "<group>"; };
+		BFEE74592977D1DE00ACB03E /* ExpressionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionParser.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */,
 				B21D83DC29763B2200E27BCA /* Operator.swift */,
 				B21D83E2297687ED00E27BCA /* Formula.swift */,
+				BFEE74592977D1DE00ACB03E /* ExpressionParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
+				BFEE745A2977D1DE00ACB03E /* ExpressionParser.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,
 				B21D83DD29763B2200E27BCA /* Operator.swift in Sources */,
 				BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */,

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		B21D83DD29763B2200E27BCA /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83DC29763B2200E27BCA /* Operator.swift */; };
 		B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E02976868700E27BCA /* FormulaTests.swift */; };
 		B21D83E3297687ED00E27BCA /* Formula.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21D83E2297687ED00E27BCA /* Formula.swift */; };
+		BF283A7F2978D58E005DD048 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF283A7E2978D58E005DD048 /* String+Extension.swift */; };
+		BF283A832978D701005DD048 /* ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF283A822978D701005DD048 /* ExtensionTests.swift */; };
 		BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */; };
 		BF9AE302297658C00021D14E /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE301297658C00021D14E /* Double+Extension.swift */; };
 		BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9AE30429765ABB0021D14E /* CalculateItem.swift */; };
@@ -40,6 +42,8 @@
 		B21D83DC29763B2200E27BCA /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		B21D83E02976868700E27BCA /* FormulaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaTests.swift; sourceTree = "<group>"; };
 		B21D83E2297687ED00E27BCA /* Formula.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formula.swift; sourceTree = "<group>"; };
+		BF283A7E2978D58E005DD048 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		BF283A822978D701005DD048 /* ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionTests.swift; sourceTree = "<group>"; };
 		BF9AE2F2297635580021D14E /* CalculatorItemQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorItemQueue.swift; sourceTree = "<group>"; };
 		BF9AE301297658C00021D14E /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
 		BF9AE30429765ABB0021D14E /* CalculateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateItem.swift; sourceTree = "<group>"; };
@@ -79,6 +83,7 @@
 				B21D83D52976311000E27BCA /* CalculatorItemQueueTests.swift */,
 				B21D83E02976868700E27BCA /* FormulaTests.swift */,
 				BFEE74552977CE9F00ACB03E /* ExpressionParserTests.swift */,
+				BF283A822978D701005DD048 /* ExtensionTests.swift */,
 			);
 			path = CalculatorTests;
 			sourceTree = "<group>";
@@ -117,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				BF9AE301297658C00021D14E /* Double+Extension.swift */,
+				BF283A7E2978D58E005DD048 /* String+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -286,6 +292,7 @@
 				B21D83E12976868700E27BCA /* FormulaTests.swift in Sources */,
 				B21D83D62976311000E27BCA /* CalculatorItemQueueTests.swift in Sources */,
 				BFEE74562977CE9F00ACB03E /* ExpressionParserTests.swift in Sources */,
+				BF283A832978D701005DD048 /* ExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -301,6 +308,7 @@
 				BF9AE30529765ABB0021D14E /* CalculateItem.swift in Sources */,
 				BF9AE2F3297635580021D14E /* CalculatorItemQueue.swift in Sources */,
 				B21D83E3297687ED00E27BCA /* Formula.swift in Sources */,
+				BF283A7F2978D58E005DD048 /* String+Extension.swift in Sources */,
 				C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Calculator/Calculator/Extensions/String+Extension.swift
+++ b/Calculator/Calculator/Extensions/String+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  String+Extension.swift
+//  Calculator
+//
+//  Created by jun on 2023/01/19.
+//
+
+import Foundation
+
+extension String {
+    func split(with target: Character) -> [String] {
+        let separator = String(target)
+        return self.components(separatedBy: separator)
+            .flatMap { [$0, separator] }
+            .dropLast()
+            .filter { $0 != "" }
+    }
+}

--- a/Calculator/Calculator/Extensions/String+Extension.swift
+++ b/Calculator/Calculator/Extensions/String+Extension.swift
@@ -10,6 +10,8 @@ import Foundation
 extension String {
     func split(with target: Character) -> [String] {
         let separator = String(target)
+        guard self.contains(target) else { return [self] }
+
         return self.components(separatedBy: separator)
             .flatMap { [$0, separator] }
             .dropLast()

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct CalculatorItemQueue<Element: CalculateItem> {
-    private(set) var items: [Element] = []
+struct CalculatorItemQueue<Element: CalculateItem>: CalculatorItemQueueProtocol {
+    private var items: [Element] = []
 
     var isEmpty: Bool {
         items.isEmpty
@@ -18,18 +18,24 @@ struct CalculatorItemQueue<Element: CalculateItem> {
         items.count
     }
 
+    var values: [Element] {
+        items
+    }
+
+    init(items: [Element]) {
+        items.forEach { element in
+            self.enqueue(item: element)
+        }
+    }
+
     mutating func enqueue(item: Element) {
         items.append(item)
     }
 
     mutating func dequeue() -> Element? {
-        guard false == items.isEmpty else {
+        guard false == isEmpty else {
             return nil
         }
         return items.removeFirst()
-    }
-
-    mutating func removeAll() {
-        items.removeAll()
     }
 }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct CalculatorItemQueue {
-    private(set) var items: [CalculateItem] = []
+struct CalculatorItemQueue<Element: CalculateItem> {
+    private(set) var items: [Element] = []
 
     var isEmpty: Bool {
         items.isEmpty
@@ -18,11 +18,11 @@ struct CalculatorItemQueue {
         items.count
     }
 
-    mutating func enqueue(item: CalculateItem) {
+    mutating func enqueue(item: Element) {
         items.append(item)
     }
 
-    mutating func dequeue() -> CalculateItem? {
+    mutating func dequeue() -> Element? {
         guard false == items.isEmpty else {
             return nil
         }

--- a/Calculator/Calculator/Model/CalculatorItemQueue.swift
+++ b/Calculator/Calculator/Model/CalculatorItemQueue.swift
@@ -8,10 +8,14 @@
 import Foundation
 
 struct CalculatorItemQueue {
-    private var items: [CalculateItem] = []
+    private(set) var items: [CalculateItem] = []
 
     var isEmpty: Bool {
         items.isEmpty
+    }
+
+    var count: Int {
+        items.count
     }
 
     mutating func enqueue(item: CalculateItem) {

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -11,7 +11,7 @@ enum ExpressionParser {
     static func parse(from input: String) -> Formula {
         let items = componentsByOperators(from: input)
         let operands = items.compactMap { Double($0) }
-        let operators = items.compactMap { $0.count == 1 ? Operator(rawValue: Character($0)) : nil }
+        let operators = items.compactMap { Operator($0) }
         return Formula(operands: operands, operators: operators)
     }
 

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,10 +9,10 @@ import Foundation
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        if input == "" {
-            return Formula()
-        }
-        return Formula(operands: [3, 4], operators: [.add])
+        let items = componentsByOperators(from: input)
+        let operands = items.compactMap { Double($0) }
+        let operators = items.compactMap { $0.count == 1 ? Operator(rawValue: Character($0)) : nil }
+        return Formula(operands: operands, operators: operators)
     }
 
     static func componentsByOperators(from input: String) -> [String] {

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -14,4 +14,11 @@ enum ExpressionParser {
         }
         return Formula(operands: [3, 4], operators: [.add])
     }
+
+    static func componentsByOperators(from input: String) -> [String] {
+        let result = Operator.allCases.reduce([input]) { (partialResult, currentOperator) in
+            return partialResult.flatMap { $0.split(with: currentOperator.rawValue )}
+        }
+        return result
+    }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -9,6 +9,9 @@ import Foundation
 
 enum ExpressionParser {
     static func parse(from input: String) -> Formula {
-        return Formula()
+        if input == "" {
+            return Formula()
+        }
+        return Formula(operands: [3, 4], operators: [.add])
     }
 }

--- a/Calculator/Calculator/Model/ExpressionParser.swift
+++ b/Calculator/Calculator/Model/ExpressionParser.swift
@@ -1,0 +1,14 @@
+//
+//  ExpressionParser.swift
+//  Calculator
+//
+//  Created by jun on 2023/01/18.
+//
+
+import Foundation
+
+enum ExpressionParser {
+    static func parse(from input: String) -> Formula {
+        return Formula()
+    }
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -26,12 +26,12 @@ struct Formula {
             throw FormulaError.wrongFormula
         }
 
-        let pairs = zip(operands.items.dropFirst(), operators.items)
+        let pairs = zip(operands.values.dropFirst(), operators.values)
         guard false == pairs.contains(where: { pair in (0.0, Operator.divide) == pair }) else {
             throw FormulaError.dividedByZero
         }
 
-        let result = pairs.reduce(operands.items[0]) { (partialResult, pair) in
+        let result = pairs.reduce(operands.values[0]) { (partialResult, pair) in
             let (currentOperand, currentOperator) = pair
             return currentOperator.calculate(lhs: partialResult, rhs: currentOperand)
         }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,7 @@ struct Formula {
     var operands = CalculatorItemQueue()
     var operators = CalculatorItemQueue()
 
-    mutating func result() -> Double {
+    mutating func result() throws -> Double {
         guard let operand1 = operands.dequeue() as? Double,
               let operand2 = operands.dequeue() as? Double,
               let operator1 = operators.dequeue() as? Operator else {

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -10,4 +10,8 @@ import Foundation
 struct Formula {
     var operands = CalculatorItemQueue()
     var operators = CalculatorItemQueue()
+
+    func result() -> Double {
+        return 0.0
+    }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -1,0 +1,13 @@
+//
+//  Formula.swift
+//  Calculator
+//
+//  Created by sei on 2023/01/17.
+//
+
+import Foundation
+
+struct Formula {
+    var operands = CalculatorItemQueue()
+    var operators = CalculatorItemQueue()
+}

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -13,33 +13,25 @@ enum FormulaError: Error {
 }
 
 struct Formula {
-    var operands = CalculatorItemQueue()
-    var operators = CalculatorItemQueue()
+    var operands: CalculatorItemQueue<Double>
+    var operators: CalculatorItemQueue<Operator>
 
-    init() { }
-
-    init(operands: [Double], operators: [Operator]) {
-        operands.forEach {
-            self.operands.enqueue(item: $0)
-        }
-        operators.forEach {
-            self.operators.enqueue(item: $0)
-        }
+    init(operands: [Double] = [], operators: [Operator] = []) {
+        self.operands = CalculatorItemQueue(items: operands)
+        self.operators = CalculatorItemQueue(items: operators)
     }
 
     func result() throws -> Double {
-        guard operands.count == operators.count + 1,
-              let operands = operands.items as? [Double],
-              let operators = operators.items as? [Operator] else {
+        guard operands.count == operators.count + 1 else {
             throw FormulaError.wrongFormula
         }
 
-        let pairs = zip(operands.dropFirst(), operators)
+        let pairs = zip(operands.items.dropFirst(), operators.items)
         guard false == pairs.contains(where: { pair in (0.0, Operator.divide) == pair }) else {
             throw FormulaError.dividedByZero
         }
 
-        let result = pairs.reduce(operands[0]) { (partialResult, pair) in
+        let result = pairs.reduce(operands.items[0]) { (partialResult, pair) in
             let (currentOperand, currentOperator) = pair
             return currentOperator.calculate(lhs: partialResult, rhs: currentOperand)
         }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -16,6 +16,17 @@ struct Formula {
     var operands = CalculatorItemQueue()
     var operators = CalculatorItemQueue()
 
+    init() { }
+
+    init(operands: [Double], operators: [Operator]) {
+        operands.forEach {
+            self.operands.enqueue(item: $0)
+        }
+        operators.forEach {
+            self.operators.enqueue(item: $0)
+        }
+    }
+
     func result() throws -> Double {
         guard operands.count == operators.count + 1,
               let operands = operands.items as? [Double],

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -7,16 +7,25 @@
 
 import Foundation
 
+enum FormulaError: Error {
+    case dividedByZero
+    case wrongFormula
+}
+
 struct Formula {
     var operands = CalculatorItemQueue()
     var operators = CalculatorItemQueue()
 
-    mutating func result() throws -> Double {
-        guard let operand1 = operands.dequeue() as? Double,
-              let operand2 = operands.dequeue() as? Double,
-              let operator1 = operators.dequeue() as? Operator else {
+    func result() throws -> Double {
+        guard operands.count == operators.count + 1 else {
+            throw FormulaError.wrongFormula
+        }
+
+        guard let operandsArray = operands.items as? [Double],
+              let operator1 = operators.items[0] as? Operator else {
             return 0.0
         }
-        return operator1.calculate(lhs: operand1, rhs: operand2)
+
+        return operator1.calculate(lhs: operandsArray[0], rhs: operandsArray[1])
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -34,14 +34,15 @@ struct Formula {
             throw FormulaError.wrongFormula
         }
 
-        let result = try zip(operands.dropFirst(), operators).reduce(operands[0]) { (partialResult, arg1) in
-            let (number, `operator`) = arg1
-            guard (0.0, Operator.divide) != (number, `operator`) else {
-                throw FormulaError.dividedByZero
-            }
-            return `operator`.calculate(lhs: partialResult, rhs: number)
+        let pairs = zip(operands.dropFirst(), operators)
+        guard false == pairs.contains(where: { pair in (0.0, Operator.divide) == pair }) else {
+            throw FormulaError.dividedByZero
         }
 
+        let result = pairs.reduce(operands[0]) { (partialResult, pair) in
+            let (currentOperand, currentOperator) = pair
+            return currentOperator.calculate(lhs: partialResult, rhs: currentOperand)
+        }
         return result
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -25,7 +25,9 @@ struct Formula {
               let operator1 = operators.items[0] as? Operator else {
             return 0.0
         }
-
+        guard (0.0, Operator.divide) != (operandsArray[1], operator1) else {
+            throw FormulaError.dividedByZero
+        }
         return operator1.calculate(lhs: operandsArray[0], rhs: operandsArray[1])
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -11,7 +11,12 @@ struct Formula {
     var operands = CalculatorItemQueue()
     var operators = CalculatorItemQueue()
 
-    func result() -> Double {
-        return 0.0
+    mutating func result() -> Double {
+        guard let operand1 = operands.dequeue() as? Double,
+              let operand2 = operands.dequeue() as? Double,
+              let operator1 = operators.dequeue() as? Operator else {
+            return 0.0
+        }
+        return operator1.calculate(lhs: operand1, rhs: operand2)
     }
 }

--- a/Calculator/Calculator/Model/Formula.swift
+++ b/Calculator/Calculator/Model/Formula.swift
@@ -17,17 +17,20 @@ struct Formula {
     var operators = CalculatorItemQueue()
 
     func result() throws -> Double {
-        guard operands.count == operators.count + 1 else {
+        guard operands.count == operators.count + 1,
+              let operands = operands.items as? [Double],
+              let operators = operators.items as? [Operator] else {
             throw FormulaError.wrongFormula
         }
 
-        guard let operandsArray = operands.items as? [Double],
-              let operator1 = operators.items[0] as? Operator else {
-            return 0.0
+        let result = try zip(operands.dropFirst(), operators).reduce(operands[0]) { (partialResult, arg1) in
+            let (number, `operator`) = arg1
+            guard (0.0, Operator.divide) != (number, `operator`) else {
+                throw FormulaError.dividedByZero
+            }
+            return `operator`.calculate(lhs: partialResult, rhs: number)
         }
-        guard (0.0, Operator.divide) != (operandsArray[1], operator1) else {
-            throw FormulaError.dividedByZero
-        }
-        return operator1.calculate(lhs: operandsArray[0], rhs: operandsArray[1])
+
+        return result
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -7,24 +7,40 @@
 
 import Foundation
 
-enum Operator: CalculateItem {
-    case add
-    case subtract
-    case multiply
-    case divide
+enum Operator: Character, CalculateItem, CaseIterable {
+    case add = "+"
+    case subtract = "−"
+    case multiply = "×"
+    case divide = "÷"
 }
 
-extension Operator: CustomStringConvertible {
-    var description: String {
+extension Operator {
+    func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {
         case .add:
-            return "+"
+            return Self.add(lhs, rhs)
         case .subtract:
-            return "−"
+            return Self.subtract(lhs, rhs)
         case .multiply:
-            return "×"
+            return Self.multiply(lhs, rhs)
         case .divide:
-            return "÷"
+            return Self.divide(lhs, rhs)
         }
+    }
+
+    private static func add(_ lhs: Double, _ rhs: Double) -> Double {
+        return lhs + rhs
+    }
+
+    private static func subtract(_ lhs: Double, _ rhs: Double) -> Double {
+        return lhs - rhs
+    }
+
+    private static func multiply(_ lhs: Double, _ rhs: Double) -> Double {
+        return lhs * rhs
+    }
+
+    private static func divide(_ lhs: Double, _ rhs: Double) -> Double {
+        return lhs / rhs
     }
 }

--- a/Calculator/Calculator/Model/Operator.swift
+++ b/Calculator/Calculator/Model/Operator.swift
@@ -12,6 +12,12 @@ enum Operator: Character, CalculateItem, CaseIterable {
     case subtract = "−"
     case multiply = "×"
     case divide = "÷"
+
+    init?(_ input: String) {
+        guard input.count == 1 else { return nil }
+        guard let value = Operator(rawValue: Character(input)) else { return nil }
+        self = value
+    }
 }
 
 extension Operator {

--- a/Calculator/Calculator/Protocols/CalculatorItemQueueProtocol.swift
+++ b/Calculator/Calculator/Protocols/CalculatorItemQueueProtocol.swift
@@ -1,0 +1,20 @@
+//
+//  CalculatorItemQueueProtocol.swift
+//  Calculator
+//
+//  Created by sei_dev on 1/20/23.
+//
+
+import Foundation
+
+protocol CalculatorItemQueueProtocol {
+    var isEmpty: Bool { get }
+    var count: Int { get }
+
+    associatedtype Element: CalculateItem
+    var values: [Element] { get }
+
+    init(items: [Element])
+    mutating func enqueue(item: Element)
+    mutating func dequeue() -> Element?
+}

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -14,8 +14,8 @@ final class CalculatorItemQueueTests: XCTestCase {
     var operatorSut: CalculatorItemQueue<Operator>!
 
     override func setUpWithError() throws {
-        doubleSut = CalculatorItemQueue<Double>()
-        operatorSut = CalculatorItemQueue<Operator>()
+        doubleSut = CalculatorItemQueue<Double>(items: [])
+        operatorSut = CalculatorItemQueue<Operator>(items: [])
     }
 
     override func tearDownWithError() throws {
@@ -47,13 +47,6 @@ final class CalculatorItemQueueTests: XCTestCase {
 
     func test_빈_queue에서_deque하면_nil이_반환된다() throws {
         XCTAssertNil(operatorSut.dequeue())
-    }
-
-    func test_Queue에_3개_enqueue_후_removeAll하면_isEmpty는_true() throws {
-        operatorSut = CalculatorItemQueue<Operator>(items: [.add, .add, .add])
-        operatorSut.removeAll()
-
-        XCTAssertTrue(operatorSut.isEmpty)
     }
 
     func test_Queue에_Double도_넣을_수_있음() throws {

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -1,5 +1,5 @@
 //
-//  CalculatorTests.swift
+//  CalculatorItemQueueTests.swift
 //  CalculatorTests
 //
 //  Created by sei on 2023/01/17.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Calculator
 
-final class CalculatorTests: XCTestCase {
+final class CalculatorItemQueueTests: XCTestCase {
 
     var sut: CalculatorItemQueue!
 

--- a/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
+++ b/Calculator/CalculatorTests/CalculatorItemQueueTests.swift
@@ -10,85 +10,66 @@ import XCTest
 
 final class CalculatorItemQueueTests: XCTestCase {
 
-    var sut: CalculatorItemQueue!
+    var doubleSut: CalculatorItemQueue<Double>!
+    var operatorSut: CalculatorItemQueue<Operator>!
 
     override func setUpWithError() throws {
-        sut = CalculatorItemQueue()
+        doubleSut = CalculatorItemQueue<Double>()
+        operatorSut = CalculatorItemQueue<Operator>()
     }
 
     override func tearDownWithError() throws {
-        sut = nil
+        doubleSut = nil
+        operatorSut = nil
     }
 
     func test_초기화했을때_isEmpty_true() throws {
-        XCTAssertTrue(sut.isEmpty)
+        XCTAssertTrue(doubleSut.isEmpty)
     }
 
     func test_operator를_넣으면_empty가_아니다() throws {
         let addOperator = Operator.add
 
-        sut.enqueue(item: addOperator)
+        operatorSut.enqueue(item: addOperator)
 
-        XCTAssertFalse(sut.isEmpty)
+        XCTAssertFalse(operatorSut.isEmpty)
     }
 
     func test_Operator_add를_enqueue하고_dequeue하면_isEmpty는_true이다() throws {
         let addOperator = Operator.add
 
-        sut.enqueue(item: addOperator)
+        operatorSut.enqueue(item: addOperator)
 
-        _ = sut.dequeue()
+        _ = operatorSut.dequeue()
 
-        XCTAssertTrue(sut.isEmpty)
+        XCTAssertTrue(operatorSut.isEmpty)
     }
 
     func test_빈_queue에서_deque하면_nil이_반환된다() throws {
-        XCTAssertNil(sut.dequeue())
+        XCTAssertNil(operatorSut.dequeue())
     }
 
     func test_Queue에_3개_enqueue_후_removeAll하면_isEmpty는_true() throws {
-        let addOperator1 = Operator.add
-        let addOperator2 = Operator.add
-        let addOperator3 = Operator.add
+        operatorSut = CalculatorItemQueue<Operator>(items: [.add, .add, .add])
+        operatorSut.removeAll()
 
-        sut.enqueue(item: addOperator1)
-        sut.enqueue(item: addOperator2)
-        sut.enqueue(item: addOperator3)
-
-        sut.removeAll()
-
-        XCTAssertTrue(sut.isEmpty)
+        XCTAssertTrue(operatorSut.isEmpty)
     }
 
     func test_Queue에_Double도_넣을_수_있음() throws {
         let doubleItem1 = 123.456
 
-        sut.enqueue(item: doubleItem1)
+        doubleSut.enqueue(item: doubleItem1)
 
-        XCTAssertFalse(sut.isEmpty)
+        XCTAssertFalse(doubleSut.isEmpty)
     }
 
     func test_Operator_subtract를_enqueue하면_isEmpty는_false이다() {
         let subtractOperator = Operator.subtract
 
-        sut.enqueue(item: subtractOperator)
+        operatorSut.enqueue(item: subtractOperator)
 
-        XCTAssertFalse(sut.isEmpty)
+        XCTAssertFalse(operatorSut.isEmpty)
     }
 
-    func test_Operator_multiply를_enqueue하면_isEmpty는_false이다() {
-        let multiplyOperator = Operator.multiply
-
-        sut.enqueue(item: multiplyOperator)
-
-        XCTAssertFalse(sut.isEmpty)
-    }
-
-    func test_Operator_divide를_enqueue하면_isEmpty는_false이다() {
-        let divideOperator = Operator.divide
-
-        sut.enqueue(item: divideOperator)
-
-        XCTAssertFalse(sut.isEmpty)
-    }
 }

--- a/Calculator/CalculatorTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorTests/CalculatorModelTests.swift
@@ -1,0 +1,37 @@
+//
+//  CalculatorModelTests.swift
+//  CalculatorTests
+//
+//  Created by jun on 2023/01/20.
+//
+
+import XCTest
+@testable import Calculator
+
+let expected = ["+", "−", "×", "÷"]
+
+final class CalculatorModelTests: XCTestCase {
+    func test_통합테스트1() throws {
+        let result = try? ExpressionParser.parse(from: "10.1+12.5÷127+8−100×13.8").result()
+        let expected = -1_267.144251968503937
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_통합테스트2() throws {
+        let result = try? ExpressionParser.parse(from: "2+3×3−1").result()
+        let expected: Double = 14
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_통합테스트3() throws {
+        let result = try? ExpressionParser.parse(from: "3÷3+2−1").result()
+        let expected: Double = 2
+        XCTAssertEqual(result, expected)
+     }
+
+    func test_통합테스트4() throws {
+        let result = try? ExpressionParser.parse(from: "1+2−3×2−3÷6").result()
+        let expected: Double = -0.5
+        XCTAssertEqual(result, expected)
+    }
+}

--- a/Calculator/CalculatorTests/CalculatorModelTests.swift
+++ b/Calculator/CalculatorTests/CalculatorModelTests.swift
@@ -8,8 +8,6 @@
 import XCTest
 @testable import Calculator
 
-let expected = ["+", "−", "×", "÷"]
-
 final class CalculatorModelTests: XCTestCase {
     func test_통합테스트1() throws {
         let result = try? ExpressionParser.parse(from: "10.1+12.5÷127+8−100×13.8").result()

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -51,4 +51,21 @@ final class ExpressionParserTests: XCTestCase {
         let expected = ["-2", "+", "-3", "−", "-4", "×", "-5", "×", "-6", "÷", "-3"]
         XCTAssertEqual(result, expected)
     }
+
+    func test_parse로_반환된_Formula에_operators_operands가_제대로_분리되었다() throws {
+        let given = "10.1+12.5÷127+8−100×13.8"
+        var formula = ExpressionParser.parse(from: given)
+        let operands: [Double] = [10.1, 12.5, 127, 8, 100, 13.8]
+        let operators: [Operator] = [.add, .divide, .add, .subtract, .multiply]
+        let expected = Formula(operands: operands, operators: operators)
+
+        for index in 0..<formula.operators.count {
+            let dequed = formula.operators.dequeue() as? Operator
+            XCTAssertEqual(operators[index], dequed)
+        }
+        for index in 0..<formula.operands.count {
+            let dequed = formula.operands.dequeue() as? Double
+            XCTAssertEqual(operands[index], dequed)
+        }
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -16,4 +16,25 @@ final class ExpressionParserTests: XCTestCase {
         XCTAssertTrue(formula.operators.isEmpty)
     }
 
+    func test_parse에_3더하기4_넣으면_Operands에_3_4_Operators에_더하기_있다() {
+        var formula = ExpressionParser.parse(from: "3\(Operator.add.rawValue)4")
+
+        guard let currentOperator = formula.operators.dequeue() as? Operator else {
+            XCTFail("operator가 아님")
+            return
+        }
+        XCTAssertTrue(currentOperator.rawValue == Operator.add.rawValue
+        )
+        XCTAssertTrue(formula.operators.isEmpty)
+
+        guard let num1 = formula.operands.dequeue() as? Double,
+              let num2 = formula.operands.dequeue() as? Double else {
+            XCTFail("double이 아님")
+            return
+        }
+        XCTAssertTrue(num1 == 3.0)
+        XCTAssertTrue(num2 == 4.0)
+        XCTAssertTrue(formula.operands.isEmpty)
+
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -12,14 +12,13 @@ final class ExpressionParserTests: XCTestCase {
     func test_parse에_빈문자열을_넣으면_빈_Formula를_반환한다() throws {
         let formula: Formula = ExpressionParser.parse(from: "")
 
-        XCTAssertTrue(formula.operands.isEmpty)
-        XCTAssertTrue(formula.operators.isEmpty)
+        XCTAssertEqual(formula, Formula())
     }
 
     func test_parse에_3더하기4_넣으면_Operands에_3_4_Operators에_더하기_있다() {
         var formula = ExpressionParser.parse(from: "3\(Operator.add.rawValue)4")
 
-        guard let currentOperator = formula.operators.dequeue() as? Operator else {
+        guard let currentOperator = formula.operators.dequeue() else {
             XCTFail("operator가 아님")
             return
         }
@@ -27,8 +26,8 @@ final class ExpressionParserTests: XCTestCase {
         )
         XCTAssertTrue(formula.operators.isEmpty)
 
-        guard let num1 = formula.operands.dequeue() as? Double,
-              let num2 = formula.operands.dequeue() as? Double else {
+        guard let num1 = formula.operands.dequeue(),
+              let num2 = formula.operands.dequeue() else {
             XCTFail("double이 아님")
             return
         }
@@ -57,15 +56,25 @@ final class ExpressionParserTests: XCTestCase {
         var formula = ExpressionParser.parse(from: given)
         let operands: [Double] = [10.1, 12.5, 127, 8, 100, 13.8]
         let operators: [Operator] = [.add, .divide, .add, .subtract, .multiply]
-        let expected = Formula(operands: operands, operators: operators)
+        _ = Formula(operands: operands, operators: operators)
 
         for index in 0..<formula.operators.count {
-            let dequed = formula.operators.dequeue() as? Operator
+            let dequed = formula.operators.dequeue()
             XCTAssertEqual(operators[index], dequed)
         }
         for index in 0..<formula.operands.count {
-            let dequed = formula.operands.dequeue() as? Double
+            let dequed = formula.operands.dequeue()
             XCTAssertEqual(operands[index], dequed)
         }
+    }
+
+    func test_parse로_반환된_Formula에_operators_operands가_제대로_분리되었다2() throws {
+        let given = "10.1+12.5÷127+8−100×13.8"
+        let formula = ExpressionParser.parse(from: given)
+        let operands: [Double] = [10.1, 12.5, 127, 8, 100, 13.8]
+        let operators: [Operator] = [.add, .divide, .add, .subtract, .multiply]
+        let expected = Formula(operands: operands, operators: operators)
+
+        XCTAssertEqual(formula, expected)
     }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -37,4 +37,18 @@ final class ExpressionParserTests: XCTestCase {
         XCTAssertTrue(formula.operands.isEmpty)
 
     }
+
+    func test_모든연산자기준으로_양의정수를_split한다() throws {
+        let given = "2+3−4×5×6÷3"
+        let result = ExpressionParser.componentsByOperators(from: given)
+        let expected = ["2", "+", "3", "−", "4", "×", "5", "×", "6", "÷", "3"]
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_모든연산자기준으로_음의정수를_split한다() throws {
+        let given = "-2+-3−-4×-5×-6÷-3"
+        let result = ExpressionParser.componentsByOperators(from: given)
+        let expected = ["-2", "+", "-3", "−", "-4", "×", "-5", "×", "-6", "÷", "-3"]
+        XCTAssertEqual(result, expected)
+    }
 }

--- a/Calculator/CalculatorTests/ExpressionParserTests.swift
+++ b/Calculator/CalculatorTests/ExpressionParserTests.swift
@@ -1,0 +1,19 @@
+//
+//  ExpressionParserTests.swift
+//  CalculatorTests
+//
+//  Created by jun on 2023/01/18.
+//
+
+import XCTest
+@testable import Calculator
+
+final class ExpressionParserTests: XCTestCase {
+    func test_parse에_빈문자열을_넣으면_빈_Formula를_반환한다() throws {
+        let formula: Formula = ExpressionParser.parse(from: "")
+
+        XCTAssertTrue(formula.operands.isEmpty)
+        XCTAssertTrue(formula.operators.isEmpty)
+    }
+
+}

--- a/Calculator/CalculatorTests/ExtensionTests.swift
+++ b/Calculator/CalculatorTests/ExtensionTests.swift
@@ -1,0 +1,19 @@
+//
+//  ExtensionTests.swift
+//  CalculatorTests
+//
+//  Created by jun on 2023/01/19.
+//
+
+import XCTest
+@testable import Calculator
+
+final class ExtensionTests: XCTestCase {
+
+    func test_더하기기호를_기준으로_split하면_더하기기호를_포함하여_나눠진다() throws {
+        let given = "2+3-4*5+6"
+        let result = given.split(with: "+")
+        let expected = ["2", "+", "3-4*5", "+", "6"]
+        XCTAssertEqual(result, expected)
+    }
+}

--- a/Calculator/CalculatorTests/Extensions.swift
+++ b/Calculator/CalculatorTests/Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  Extensions.swift
+//  CalculatorTests
+//
+//  Created by sei_dev on 1/19/23.
+//
+
+import Foundation
+@testable import Calculator
+
+extension Formula: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.operands == rhs.operands && lhs.operators == rhs.operators
+    }
+}
+
+extension CalculatorItemQueue where Element: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.items == rhs.items
+    }
+}

--- a/Calculator/CalculatorTests/Extensions.swift
+++ b/Calculator/CalculatorTests/Extensions.swift
@@ -16,6 +16,6 @@ extension Formula: Equatable {
 
 extension CalculatorItemQueue where Element: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.items == rhs.items
+        return lhs.values == rhs.values
     }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -79,4 +79,18 @@ final class FormulaTests: XCTestCase {
         XCTAssertNoThrow(try sut.result())
     }
 
+    func test_operands_6개_operator_5개_result() throws {
+        let operands = [1.0, 2.0, 3.0, 2.0, 3.0, 6.0]
+        operands.forEach { number in
+            sut.operands.enqueue(item: number)
+        }
+
+        let operators: [Operator] = [.add, .subtract, .multiply, .subtract, .divide]
+        operators.forEach { `operator` in
+            sut.operators.enqueue(item: `operator`)
+        }
+
+        XCTAssertEqual(try? sut.result(), -0.5)
+    }
+
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -49,4 +49,16 @@ final class FormulaTests: XCTestCase {
     func test_Formula가_비어있을때_result호출시_에러() throws {
         XCTAssertThrowsError(try sut.result())
     }
+
+    func test_0으로_나눌때_에러() throws {
+        let operand1 = 1.0
+        let operand2 = 0.0
+        sut.operands.enqueue(item: operand1)
+        sut.operands.enqueue(item: operand2)
+
+        let operator1 = Operator.divide
+        sut.operators.enqueue(item: operator1)
+
+        XCTAssertThrowsError(try sut.result())
+    }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -25,24 +25,12 @@ final class FormulaTests: XCTestCase {
     }
 
     func test_operands가_1_2이고_operator가_add일때_result는_3이다() throws {
-        let operand1 = 1.0
-        let operand2 = 2.0
-        sut.operands.enqueue(item: operand1)
-        sut.operands.enqueue(item: operand2)
-
-        let operator1 = Operator.add
-        sut.operators.enqueue(item: operator1)
-
+        sut = Formula(operands: [1.0, 2.0], operators: [.add])
         XCTAssertEqual(try? sut.result(), 3.0)
     }
 
     func test_Formula의_operands가_operator_보다_1개_많지_않으면_에러() throws {
-        let operand1 = 1.0
-        sut.operands.enqueue(item: operand1)
-
-        let operator1 = Operator.add
-        sut.operators.enqueue(item: operator1)
-
+        sut = Formula(operands: [1.0], operators: [.add])
         XCTAssertThrowsError(try sut.result())
     }
 
@@ -51,13 +39,7 @@ final class FormulaTests: XCTestCase {
     }
 
     func test_0으로_나눌때_에러() throws {
-        let operand1 = 1.0
-        let operand2 = 0.0
-        sut.operands.enqueue(item: operand1)
-        sut.operands.enqueue(item: operand2)
-
-        let operator1 = Operator.divide
-        sut.operators.enqueue(item: operator1)
+        sut = Formula(operands: [1.0, 0.0], operators: [.divide])
 
         do {
             let result = try sut.result()
@@ -68,27 +50,16 @@ final class FormulaTests: XCTestCase {
     }
 
     func test_0으로_뺄때_에러아님() throws {
-        let operand1 = 1.0
-        let operand2 = 0.0
-        sut.operands.enqueue(item: operand1)
-        sut.operands.enqueue(item: operand2)
-
-        let operator1 = Operator.subtract
-        sut.operators.enqueue(item: operator1)
+        sut = Formula(operands: [1.0, 0.0], operators: [.subtract])
 
         XCTAssertNoThrow(try sut.result())
     }
 
     func test_operands_6개_operator_5개_result() throws {
         let operands = [1.0, 2.0, 3.0, 2.0, 3.0, 6.0]
-        operands.forEach { number in
-            sut.operands.enqueue(item: number)
-        }
-
         let operators: [Operator] = [.add, .subtract, .multiply, .subtract, .divide]
-        operators.forEach { `operator` in
-            sut.operators.enqueue(item: `operator`)
-        }
+
+        sut = Formula(operands: operands, operators: operators)
 
         XCTAssertEqual(try? sut.result(), -0.5)
     }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -28,4 +28,16 @@ final class FormulaTests: XCTestCase {
         XCTAssertEqual(sut.result(), 0.0)
     }
 
+    func test_operands가_1_2이고_operator가_add일때_result는_3이다() throws {
+        let operand1 = 1.0
+        let operand2 = 2.0
+        sut.operands.enqueue(item: operand1)
+        sut.operands.enqueue(item: operand2)
+
+        let operator1 = Operator.add
+        sut.operators.enqueue(item: operator1)
+
+        XCTAssertEqual(sut.result(), 3.0)
+    }
+
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -59,6 +59,24 @@ final class FormulaTests: XCTestCase {
         let operator1 = Operator.divide
         sut.operators.enqueue(item: operator1)
 
-        XCTAssertThrowsError(try sut.result())
+        do {
+            let result = try sut.result()
+            XCTAssertThrowsError(result)
+        } catch let error as FormulaError {
+            XCTAssertEqual(error, .dividedByZero)
+        }
     }
+
+    func test_0으로_뺄때_에러아님() throws {
+        let operand1 = 1.0
+        let operand2 = 0.0
+        sut.operands.enqueue(item: operand1)
+        sut.operands.enqueue(item: operand2)
+
+        let operator1 = Operator.subtract
+        sut.operators.enqueue(item: operator1)
+
+        XCTAssertNoThrow(try sut.result())
+    }
+
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -25,7 +25,7 @@ final class FormulaTests: XCTestCase {
     }
 
     func test_Formula가_비어있을때_result는_0이다() throws {
-        XCTAssertEqual(sut.result(), 0.0)
+        XCTAssertEqual(try? sut.result(), 0.0)
     }
 
     func test_operands가_1_2이고_operator가_add일때_result는_3이다() throws {
@@ -37,7 +37,16 @@ final class FormulaTests: XCTestCase {
         let operator1 = Operator.add
         sut.operators.enqueue(item: operator1)
 
-        XCTAssertEqual(sut.result(), 3.0)
+        XCTAssertEqual(try? sut.result(), 3.0)
     }
 
+    func test_Formula의_operands가_operator_보다_1개_많지_않으면_에러() throws {
+        let operand1 = 1.0
+        sut.operands.enqueue(item: operand1)
+
+        let operator1 = Operator.add
+        sut.operators.enqueue(item: operator1)
+
+        XCTAssertThrowsError(try sut.result())
+    }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import Calculator
 
 final class FormulaTests: XCTestCase {
     var sut: Formula!

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -1,0 +1,26 @@
+//
+//  FormulaTests.swift
+//  CalculatorTests
+//
+//  Created by sei on 2023/01/17.
+//
+
+import XCTest
+
+final class FormulaTests: XCTestCase {
+    var sut: Formula!
+
+    override func setUpWithError() throws {
+        sut = Formula()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func test_Formula_초기화하면_두_큐_isEmpty_true() throws {
+        XCTAssertTrue(sut.operands.isEmpty)
+        XCTAssertTrue(sut.operators.isEmpty)
+    }
+
+}

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -93,4 +93,17 @@ final class FormulaTests: XCTestCase {
         XCTAssertEqual(try? sut.result(), -0.5)
     }
 
+    func test_0으로_나눌때_에러_인자가_많은_경우() throws {
+        let operands = [1.0, 0.0, 3.0, 4.0, 5.0]
+        let operators: [Operator] = [.divide, .add, .multiply, .subtract]
+        sut = Formula(operands: operands, operators: operators)
+
+        do {
+            let result = try sut.result()
+            XCTAssertThrowsError(result)
+        } catch let error as FormulaError {
+            XCTAssertEqual(error, .dividedByZero)
+        }
+    }
+
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -24,10 +24,6 @@ final class FormulaTests: XCTestCase {
         XCTAssertTrue(sut.operators.isEmpty)
     }
 
-    func test_Formula가_비어있을때_result는_0이다() throws {
-        XCTAssertEqual(try? sut.result(), 0.0)
-    }
-
     func test_operands가_1_2이고_operator가_add일때_result는_3이다() throws {
         let operand1 = 1.0
         let operand2 = 2.0
@@ -47,6 +43,10 @@ final class FormulaTests: XCTestCase {
         let operator1 = Operator.add
         sut.operators.enqueue(item: operator1)
 
+        XCTAssertThrowsError(try sut.result())
+    }
+
+    func test_Formula가_비어있을때_result호출시_에러() throws {
         XCTAssertThrowsError(try sut.result())
     }
 }

--- a/Calculator/CalculatorTests/FormulaTests.swift
+++ b/Calculator/CalculatorTests/FormulaTests.swift
@@ -24,4 +24,8 @@ final class FormulaTests: XCTestCase {
         XCTAssertTrue(sut.operators.isEmpty)
     }
 
+    func test_Formula가_비어있을때_result는_0이다() throws {
+        XCTAssertEqual(sut.result(), 0.0)
+    }
+
 }

--- a/Calculator/CalculatorTests/StringExtensionTests.swift
+++ b/Calculator/CalculatorTests/StringExtensionTests.swift
@@ -1,5 +1,5 @@
 //
-//  ExtensionTests.swift
+//  StringExtensionTests.swift
 //  CalculatorTests
 //
 //  Created by jun on 2023/01/19.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Calculator
 
-final class ExtensionTests: XCTestCase {
+final class StringExtensionTests: XCTestCase {
 
     func test_더하기기호를_기준으로_split하면_더하기기호를_포함하여_나눠진다() throws {
         let given = "2+3-4*5+6"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# ios-calculator
-계산기 프로젝트 저장소입니다.
+# Calculator
+
+## 👊🏻 트러블슈팅
+
+### 🤔 문제 상황
+
+- 객체들이 잘 동작하는지 테스트할 때 각 객체를 XCTAssertEqual로 테스트하고 싶었어요.
+  - 그렇지 않으면, enqueue와 dequeue를 반복하며 각 element들을 1:1 비교해야 했는데, 이것이 번거로웠기 때문입니다.
+- 테스트를 위해 객체간 값 비교를 해야했는데 protocol인 `CalculateItem`이 빈 프로토콜이라 값비교가 되지 않았어요.
+
+### 👨‍💻 해결 과정
+
+1. **각 객체는 Test 모듈 안에서만 `Equatable`을 adopt합니다.**
+   - 비교하려는 객체가 `Equatable` 프로토콜을 adopt하고 `static func ==` method를 구현하면 이를 해결할 수 있어요.
+   - 그런데 이 부분은 구현하려는 모듈 내에서는 필요하지 않은 기능이예요.
+   - 그러므로 Test 모듈 안에서만 `Equatable`을 conform하도록 해당 모듈 안에서 `Extension.swift` 파일을 만들어서 이를 구현했습니다.
+2. **CalculatorItemQueue는 CalculateItem Protocol을 따르는 Element를 받도록 Generic을 활용한다.**
+
+   - 기존 구현에서 `CalculatorItemQueue`의 items의 타입은 `[CalculateItem]` 이었어요.
+   - `Formula`는 `CalculatorItemQueue`로 이루어져있고, `CalculatorItemQueue`는 `CalculateItem`으로 이루어져 있기 때문에 두 객체가 `Equatable`하기 위해서 `CalculateItem` 역시 `Equatable`해야 한다고 생각했어요.
+   - 그러나 `CalculateItem`은 빈 프로토콜이므로 Equatable일 수 없고, 따라서 기존의 코드로는 Queue와 Formula가 Equatable할 수 없다고 판단했어요.
+   - 이를 해결하기 위해 `CalculatorItemQueue`에 `Generic`을 추가했어요.
+     ```swift
+     struct CalculatorItemQueue<Element: CalculateItem>: CalculatorItemQueueProtocol { }
+     struct Formula {
+         var operands: CalculatorItemQueue<Double>
+         var operators: CalculatorItemQueue<Operator>
+     }
+     ```
+   - 그리고 Tests 모듈에는 아래와 같이 각 객체에 `Equatable`을 구현한 `Extension.swift`를 작성했어요.
+
+     ```swift
+     extension Formula: Equatable {
+         public static func == (lhs: Self, rhs: Self) -> Bool {
+             return lhs.operands == rhs.operands && lhs.operators == rhs.operators
+         }
+     }
+
+     extension CalculatorItemQueue where Element: Equatable {
+         public static func == (lhs: Self, rhs: Self) -> Bool {
+             return lhs.values == rhs.values
+         }
+     }
+     ```
+
+   - `Element`가 `Equatable`인 `CalculatorItemQueue`에 한해 `Equatable`을 정의할 수 있게 되었습니다.
+   - `Formula`의 `CalculatorItemQueue` 타입 properties는 `Double`, `Operator`로 모두 `Equatable`인 `Element`입니다.
+   - 객체의 `Equatable`의 기반이 Equatable을 준수하는 `Double`과 `Operator`로부터 나오므로, 이제 두 객체 모두 Equatable을 정의할 수 있게 되었어요!
+   - 거기다가 기존 모듈 구현부에는 Formula의 result를 수행할 때 operand와 operator를 Double, Operator로 다운 캐스팅을 해야했는데, 제네릭을 사용하면서 다운캐스팅이 필요 없어지는 부수 효과도 있었습니다😆.
+
+## 🧹 이번주 학습내용 요점 정리
+
+### 🚥 TDD
+
+- `테스트`(🔴)를 먼저 추가하고 이를 위한 `구현`(🟢)을 진행하고 마지막으로 필요하다면 `리팩토링`(🔵)을 하여 TDD를 진행했습니다.
+
+<img width="1600" alt="스크린샷 2023-01-20 13 57 37" src="https://user-images.githubusercontent.com/22979718/213620489-3740b10a-3360-4d1e-ad43-8cc4753c7543.png">
+
+### ❓ Optional과 Non-optional value의 equality
+
+- 옵셔널과 일반 타입은 서로 다른 타입으로 알고 있어서 `==`를 통한 단순비교가 안될 것이라 생각했는데, 실제로 값 비교가 가능하여 조사를 진행했습니다. swift 레포지토리의 `public static func ==` 구현부분([링크](https://github.com/apple/swift/blob/e032b3191d8a3244ba1ee177c447d74325c602b1/stdlib/public/core/Optional.swift#L399))을 참고하여 실제 구현내용을 확인했고 아래와 같이 동작하는 것을 확인했습니다.
+  1. Double == Optional(Double) -> Optional(Double) == Optional(Double)
+  2. nil == nil
+  3. Double == Double -> Double == Double
+
+<img width="913" alt="스크린샷 2023-01-20 14 21 40" src="https://user-images.githubusercontent.com/22979718/213623174-2a756f68-8295-4748-80a9-744685ae554c.png">
+
+### 📂 iOS 폴더 구조
+
+- iOS 프로젝트 관련하여 MVC(Model, View, Controller) 패턴 및 Protocol, Extension 파일 관련하여 폴더를 나누는 방법에 대해 고민해봤습니다.
+- 참고할 수 있는 공식문서가 있으면 좋았겠지만 찾지 못해서 Firefox 오픈소스를 참고하여 아래와 같이폴더 구조를 나눠봤습니다.
+
+  <img width="330" alt="스크린샷 2023-01-20 14 06 00" src="https://user-images.githubusercontent.com/22979718/213621606-3f5396e8-922e-4f0f-afc1-d3122979d457.png">
+
+## 다음주 프로젝트 계획
+
+- [ ] 두 번째 리뷰에 대한 피드백
+- [ ] UI 만들기


### PR DESCRIPTION
# 🧮 계산기 프로젝트

안녕하세요 코리! 🐶 @corykim0829
설은 잘 보내셨나요?
이제 정말 겨울이 온거 같아요 옷을 껴입어도 정말 춥네요 🥶
STEP2에서는 제시된 UML을 바탕으로 코드를 작성하는 요구사항이 있었는데요,
테스트 코드 작성을 위해 테스트 모듈에만 Equatable을 채택하여 `static func ==` method를 구현해준 부분이 있어요! 이에 대해 코리는 어떻게 생각하시는지 의견을 듣고 싶습니다.
그럼 STEP3까지 잘 부탁드리겠습니다 !! 🫡

## Step2: 요구 사항 및 구현 사항

### 요구 사항 정리

```markdown
## Step 2 : 계산 타입 및 주변 타입 구현
1. 아래 제시한 UML대로 연산과 관련한 타입을 구현합니다
    - UML에 표기한 사항은 모두 구현해야합니다
    - 추가하고 싶은 사항이 있다면 `리뷰어와 협의 후` 진행하세요
        - 새로운 타입 추가 외에 UML의 기존 내용 수정은 불가합니다
        - 리뷰어와 협의없이 진행 시 스텝 기한내 완료 포인트는 없습니다
2. 변수보다는 상수를, 반복문 조건문 보다는 고차함수를 더 활용하도록 노력해보세요
3. 본인이 희망하면 TDD를 적극 수행해보세요
    - TDD를 활용한 구현은 의존성 관계 그래프의 최말단 타입부터 구현하면 편리합니다
        - 예) `CalculatorItemQueue` → `Formula` → `ExpressionParser` 순서
4. 참고할 사항
    - 계산기가 입력받은 숫자와 연산자는 연산큐에 쌓입니다
    - 0으로 나누기를 시도하는 경우 적절한 오류처리를 할 수 있도록 합니다
    - 각종 예외사항과 오류사항에 대해 대처할 수 있으면 더욱 좋습니다

📖 아래 UML은 이번 프로젝트에서 구현할 코드의 UML입니다. 자신의 생각과 다른점도, 아쉬운 점도 있을 수 있습니다. 하지만 이번 프로젝트에서 제시된 UML대로 코드를 작성해주기 바랍니다.
```

## 🧹 고민한 부분
### 🚥 TDD

- `테스트`(🔴)를 먼저 추가하고 이를 위한 `구현`(🟢)을 진행하고 마지막으로 필요하다면 `리팩토링`(🔵)을 하여 TDD를 진행했습니다.
- Step 2에서도 TDD를 진행해보려고 노력했지만 개발속도가 더뎌서 중간부터는 구현을 먼저하고 테스트 코드를 나중에 작성하는 방법으로 진행했습니다. 🫥
- ❓ 아무것도 작성하지 않은 백지에서 TDD로 쌓아 올리는게 생각보다 어려웠어요. TDD에 대한 전반적인 코리의 의견이 궁금해요. 유용하다고 생각하는지, 자주 사용하는지, 특별히 적용하면 좋을 때가 있다고 생각하는지 등등

<img width="1600" alt="스크린샷 2023-01-20 13 57 37" src="https://user-images.githubusercontent.com/22979718/213620489-3740b10a-3360-4d1e-ad43-8cc4753c7543.png">

### ⭐️ 더 편한 테스트를 위해 Equatable 채택하기

#### 🤔 문제 상황

- 객체들이 잘 동작하는지 테스트할 때 각 객체를 XCTAssertEqual로 테스트하고 싶었어요.
  - 그렇지 않으면, enqueue와 dequeue를 반복하며 각 element들을 1:1 비교해야 했는데, 이것이 번거로웠기 때문입니다.
- 테스트를 위해 객체간 값 비교를 해야했는데 protocol인 `CalculateItem`이 빈 프로토콜이라 값비교가 되지 않았어요.

#### 👨‍💻 해결 과정

1. **각 객체는 Test 모듈 안에서만 `Equatable`을 adopt합니다.**
   - 비교하려는 객체가 `Equatable` 프로토콜을 adopt하고 `static func ==` method를 구현하면 이를 해결할 수 있어요.
   - 그런데 이 부분은 구현하려는 모듈 내에서는 필요하지 않은 기능이예요.
   - 그러므로 Test 모듈 안에서만 `Equatable`을 conform하도록 해당 모듈 안에서 `Extension.swift` 파일을 만들어서 이를 구현했습니다.
2. **CalculatorItemQueue는 CalculateItem Protocol을 따르는 Element를 받도록 Generic을 활용한다.**

   - 기존 구현에서 `CalculatorItemQueue`의 items의 타입은 `[CalculateItem]` 이었어요.
   - `Formula`는 `CalculatorItemQueue`로 이루어져있고, `CalculatorItemQueue`는 `CalculateItem`으로 이루어져 있기 때문에 두 객체가 `Equatable`하기 위해서 `CalculateItem` 역시 `Equatable`해야 한다고 생각했어요.
   - 그러나 `CalculateItem`은 빈 프로토콜이므로 Equatable일 수 없고, 따라서 기존의 코드로는 Queue와 Formula가 Equatable할 수 없다고 판단했어요.
   - 이를 해결하기 위해 `CalculatorItemQueue`에 `Generic`을 추가했어요.
     ```swift
     struct CalculatorItemQueue<Element: CalculateItem>: CalculatorItemQueueProtocol { }
     struct Formula {
         var operands: CalculatorItemQueue<Double>
         var operators: CalculatorItemQueue<Operator>
     }
     ```
   - 그리고 Tests 모듈에는 아래와 같이 각 객체에 `Equatable`을 구현한 `Extension.swift`를 작성했어요.

     ```swift
     extension Formula: Equatable {
         public static func == (lhs: Self, rhs: Self) -> Bool {
             return lhs.operands == rhs.operands && lhs.operators == rhs.operators
         }
     }

     extension CalculatorItemQueue where Element: Equatable {
         public static func == (lhs: Self, rhs: Self) -> Bool {
             return lhs.values == rhs.values
         }
     }
     ```

   - `Element`가 `Equatable`인 `CalculatorItemQueue`에 한해 `Equatable`을 정의할 수 있게 되었습니다.
   - `Formula`의 `CalculatorItemQueue` 타입 properties는 `Double`, `Operator`로 모두 `Equatable`인 `Element`입니다.
   - 객체의 `Equatable`의 기반이 Equatable을 준수하는 `Double`과 `Operator`로부터 나오므로, 이제 두 객체 모두 Equatable을 정의할 수 있게 되었어요!
   - 거기다가 기존 모듈 구현부에는 Formula의 result를 수행할 때 operand와 operator를 Double, Operator로 다운 캐스팅을 해야했는데, 제네릭을 사용하면서 다운캐스팅이 필요 없어지는 부수 효과도 있었습니다😆

❓ 궁금증
- 결론적으로 테스트에만 필요한 Equality 프로토콜을 채택하기 위해 제네릭을 활용하는 방식으로 기존 구현을 변경했습니다. 물론 이를 활용하면서 연산 시 타입 다운 캐스팅을 하지 않아도 되는 장점이 생겼지만, 테스트를 위해 기존 구현을 변경하는 행위 자체는 지양하는게 좋을지 궁금합니다!