### PR TITLE
Calculator [STEP 3] Joo, Lust3r

### DIFF
--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1210;
+				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
@@ -349,7 +349,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -467,6 +467,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
@@ -492,6 +493,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		90A26ED9298BB29000A9C749 /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A26ED8298BB29000A9C749 /* UIStackView+Extension.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
 		C713D9442570E5EB001C3AFC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9432570E5EB001C3AFC /* SceneDelegate.swift */; };
 		C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9452570E5EB001C3AFC /* ViewController.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		90A26ED8298BB29000A9C749 /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C713D9412570E5EB001C3AFC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C713D9432570E5EB001C3AFC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				D94FF8362974D9B100F7A551 /* CalculateItemQueue.swift */,
 				D94FF84A29751BD500F7A551 /* CalculateItem.swift */,
 				D94BC7B5297670DD00186B6A /* ExpressionParser.swift */,
+				90A26ED8298BB29000A9C749 /* UIStackView+Extension.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -239,6 +242,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90A26ED9298BB29000A9C749 /* UIStackView+Extension.swift in Sources */,
 				C713D9462570E5EB001C3AFC /* ViewController.swift in Sources */,
 				D94BC7B6297670DD00186B6A /* ExpressionParser.swift in Sources */,
 				C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */,

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UIViewController {
     @IBAction func allClear(_ sender: UIButton) {
         operandLabel.text?.removeAll()
         operandLabel.text = "0"
+        operatorLabel.text = ""
         isDecimal = false
     }
 
@@ -78,6 +79,9 @@ class ViewController: UIViewController {
             return
         }
         guard enteredOperand != "0" else {
+            if calculationFormula == "+" {
+                calculationFormula.removeAll()
+            }
             operatorLabel.text = `operator`
             return
         }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController {
         operandLabel.text = "0"
         operatorLabel.text = ""
         isDecimal = false
+        calculationFormula = "+"
     }
 
     @IBAction func clearEntry(_ sender: UIButton) {
@@ -93,5 +94,20 @@ class ViewController: UIViewController {
         operandLabel.text = "0"
         isDecimal = false
     }
+
+    @IBAction func calculateResult(_ sender: UIButton) {
+        guard let enteredOperator = operatorLabel.text,
+              var enteredOperand = operandLabel.text else {
+            return
+        }
+        calculationFormula += enteredOperator + enteredOperand
+        operatorLabel.text = ""
+        isDecimal = false
+        var formula = ExpressionParser.parse(from: calculationFormula)
+        operandLabel.text = String(formula.result())
+
+        calculationFormula = "+"
+    }
+
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -14,7 +14,6 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
 
     @IBOutlet weak var scrollView: UIScrollView!
@@ -34,7 +33,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func clearEntry(_ sender: UIButton) {
-        guard enteredOperand != "0", enteredOperand != String(Double.nan), isCalculated == false else {
+        guard isInitialOperand() == false, enteredOperand != String(Double.nan), isCalculated == false else {
             return
         }
         if enteredOperand.removeLast() == "." {
@@ -47,7 +46,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func changeSign(_ sender: UIButton) {
-        guard enteredOperand != "0" else {
+        guard isInitialOperand() == false else {
             return
         }
         if enteredOperand.first == "-" {
@@ -75,10 +74,10 @@ class ViewController: UIViewController {
             enteredOperand = "0"
             isCalculated = false
         }
-        guard enteredOperand != "0" || (number != "0" && number != "00") else {
+        guard isInitialOperand() == false || (number != "0" && number != "00") else {
             return
         }
-        if enteredOperand == "0" {
+        if isInitialOperand() {
             enteredOperand = number
         } else {
             enteredOperand += number
@@ -91,7 +90,7 @@ class ViewController: UIViewController {
               let enteredOperator = operatorLabel.text else {
             return
         }
-        guard enteredOperand != "0" else {
+        guard isInitialOperand() == false else {
             if calculationFormula == "+" {
                 calculationFormula.removeAll()
             }
@@ -119,7 +118,7 @@ class ViewController: UIViewController {
         isDecimal = false
         isCalculated = true
         var formula = ExpressionParser.parse(from: calculationFormula)
-        var resultValue = String(formula.result())
+        let resultValue = String(formula.result())
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         enteredOperand = resultValue
         operandLabel.text = formattingNumber(enteredOperand)
@@ -164,6 +163,10 @@ class ViewController: UIViewController {
             return formattingNumber(integerOfOperand) + decimalOfOperand
         }
         return formattingNumber(operand)
+    }
+
+    private func isInitialOperand() -> Bool {
+        return enteredOperand == "0"
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController {
         operatorLabel.text = ""
         calculationFormula = "+"
         enteredOperand = "0"
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
 
         formulaStackViews.removeAllArrangedSubviews()
     }
@@ -42,7 +42,7 @@ class ViewController: UIViewController {
         if enteredOperand.isEmpty {
             enteredOperand = "0"
         }
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
     }
 
     @IBAction func changeSign(_ sender: UIButton) {
@@ -54,16 +54,21 @@ class ViewController: UIViewController {
         } else {
             enteredOperand = "-" + enteredOperand
         }
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
     }
 
     @IBAction func addDecimalPoint(_ sender: UIButton) {
         guard isDecimal == false else {
             return
         }
+        // 테스트 1
+        print(enteredOperand)
         enteredOperand += "."
         isDecimal = true
-        operandLabel.text = enteredOperand
+        guard let formattedNumber = formattingNumber(enteredOperand) else {
+            return
+        }
+        operandLabel.text = formattedNumber + "."
     }
 
     @IBAction func addNumber(_ sender: UIButton) {
@@ -78,7 +83,7 @@ class ViewController: UIViewController {
         } else {
             enteredOperand += number
         }
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
     }
 
     @IBAction func addOperator(_ sender: UIButton) {
@@ -100,13 +105,13 @@ class ViewController: UIViewController {
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         operatorLabel.text = `operator`
         enteredOperand = "0"
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
         isDecimal = false
         scrollView.contentOffset.y = scrollView.contentSize.height
     }
 
     @IBAction func calculateResult(_ sender: UIButton) {
-        guard let enteredOperator = operatorLabel.text else {
+        guard let enteredOperator = operatorLabel.text, calculationFormula != "+" else {
             return
         }
         calculationFormula += enteredOperator + enteredOperand
@@ -120,7 +125,7 @@ class ViewController: UIViewController {
         }
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         enteredOperand = resultValue
-        operandLabel.text = enteredOperand
+        operandLabel.text = formattingNumber(enteredOperand)
         calculationFormula = "+"
         scrollView.contentOffset.y = scrollView.contentSize.height
     }
@@ -130,7 +135,7 @@ class ViewController: UIViewController {
         let enteredOperatorLabel = UILabel()
         let enteredOperandLabel = UILabel()
 
-        enteredOperandLabel.text = operand
+        enteredOperandLabel.text = formattingNumber(operand)
         enteredOperatorLabel.text = `operator`
         enteredOperandLabel.textColor = .white
         enteredOperatorLabel.textColor = .white
@@ -140,6 +145,13 @@ class ViewController: UIViewController {
         formulaStackView.addArrangedSubview(enteredOperandLabel)
 
         formulaStackViews.addArrangedSubview(formulaStackView)
+    }
+
+    private func formattingNumber(_ number: String) -> String? {
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = 20
+        formatter.numberStyle = .decimal
+        return formatter.string(for: Double(number))
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,11 +8,27 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    var calculationFormula: String = "+"
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
 
-
+    @IBAction func addNumber(_ sender: UIButton) {
+        guard let number = sender.currentTitle else {
+            return
+        }
+        print(isOperator())
+    }
+    func isOperator() -> Bool {
+        var result = false
+        for `operator` in Operator.allCases {
+            guard calculationFormula.hasSuffix(String(`operator`.rawValue)) else {
+                continue
+            }
+            result = true
+        }
+        return result
+    }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
             enteredOperand = "0"
             isCalculated = false
         }
-        guard isInitialOperand() == false || (number != "0" && number != "00") else {
+        guard isInitialOperand() == false || isZero(number) else {
             return
         }
         if isInitialOperand() {
@@ -166,5 +166,9 @@ class ViewController: UIViewController {
 
     private func isInitialOperand() -> Bool {
         return enteredOperand == "0"
+    }
+
+    private func isZero(_ value: String) -> Bool {
+        return value == "0" || value == "00"
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 class ViewController: UIViewController {
     var calculationFormula: String = "+"
     var isDecimal: Bool = false
+    var isCalculated: Bool = false
     var enteredOperand: String = "0"
 
     override func viewDidLoad() {
@@ -33,7 +34,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func clearEntry(_ sender: UIButton) {
-        guard enteredOperand != "0", enteredOperand != String(Double.nan) else {
+        guard enteredOperand != "0", enteredOperand != String(Double.nan), isCalculated == false else {
             return
         }
         if enteredOperand.removeLast() == "." {
@@ -72,6 +73,10 @@ class ViewController: UIViewController {
     @IBAction func addNumber(_ sender: UIButton) {
         guard let number = sender.currentTitle else {
             return
+        }
+        if isCalculated {
+            enteredOperand = "0"
+            isCalculated = false
         }
         guard enteredOperand != "0" || (number != "0" && number != "00") else {
             return
@@ -115,12 +120,9 @@ class ViewController: UIViewController {
         calculationFormula += enteredOperator + enteredOperand
         operatorLabel.text = ""
         isDecimal = false
+        isCalculated = true
         var formula = ExpressionParser.parse(from: calculationFormula)
         var resultValue = String(formula.result())
-        if resultValue.hasSuffix(".0") {
-            resultValue.removeLast()
-            resultValue.removeLast()
-        }
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         enteredOperand = resultValue
         operandLabel.text = formattingNumber(enteredOperand)

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -24,6 +24,15 @@ class ViewController: UIViewController {
         calculationFormula += number
     }
 
+    @IBAction func addOperator(_ sender: UIButton) {
+        guard let `operator` = sender.currentTitle else {
+            return
+        }
+        guard isNumber() else {
+            return
+        }
+    }
+
     func isOperator() -> Bool {
         var result = false
         for `operator` in Operator.allCases {
@@ -33,6 +42,13 @@ class ViewController: UIViewController {
             result = true
         }
         return result
+    }
+
+    func isNumber() -> Bool {
+        guard let lastElement = calculationFormula.last, lastElement.isNumber else {
+            return false
+        }
+        return true
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,11 +7,12 @@
 import UIKit
 
 class ViewController: UIViewController {
+    private let zero: String = "0"
+    private let point: String = "."
     private var calculationFormula: String = "+"
     private var isDecimal: Bool = false
     private var isCalculated: Bool = false
     private var enteredOperand: String = "0"
-    private let point = "."
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,8 +28,7 @@ class ViewController: UIViewController {
         isDecimal = false
         operatorLabel.text = ""
         calculationFormula = "+"
-        enteredOperand = "0"
-        operandLabel.text = formattingNumber(enteredOperand)
+        initializeOperand()
         formulaStackViews.removeAllArrangedSubviews()
     }
 
@@ -39,8 +39,9 @@ class ViewController: UIViewController {
         if enteredOperand.removeLast() == Character(point) {
             isDecimal = false
         }
-        if enteredOperand.isEmpty {
-            enteredOperand = "0"
+        guard enteredOperand.isEmpty == false else {
+            initializeOperand()
+            return
         }
         operandLabel.text = formattingNumber(enteredOperand)
     }
@@ -71,10 +72,10 @@ class ViewController: UIViewController {
             return
         }
         if isCalculated {
-            enteredOperand = "0"
+            enteredOperand = zero
             isCalculated = false
         }
-        guard isInitialOperand() == false || isZero(number) else {
+        guard isInitialOperand() == false || isZero(number) == false else {
             return
         }
         if isInitialOperand() {
@@ -98,13 +99,12 @@ class ViewController: UIViewController {
             return
         }
         if enteredOperand.hasSuffix(point) {
-            enteredOperand += "0"
+            enteredOperand += zero
         }
         calculationFormula += enteredOperator + enteredOperand
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         operatorLabel.text = `operator`
-        enteredOperand = "0"
-        operandLabel.text = formattingNumber(enteredOperand)
+        initializeOperand()
         isDecimal = false
         scrollView.contentOffset.y = scrollView.contentSize.height
     }
@@ -165,10 +165,15 @@ class ViewController: UIViewController {
     }
 
     private func isInitialOperand() -> Bool {
-        return enteredOperand == "0"
+        return enteredOperand == zero
     }
 
     private func isZero(_ value: String) -> Bool {
-        return value == "0" || value == "00"
+        return value == zero || value == "00"
+    }
+
+    private func initializeOperand() {
+        enteredOperand = zero
+        operandLabel.text = zero
     }
 }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var operandLabel: UILabel!
+    @IBOutlet weak var formulaStackViews: UIStackView!
 
     @IBAction func allClear(_ sender: UIButton) {
         operandLabel.text?.removeAll()
@@ -28,6 +29,9 @@ class ViewController: UIViewController {
 
     @IBAction func clearEntry(_ sender: UIButton) {
         guard var enteredOperand = operandLabel.text, enteredOperand != "0" else {
+            return
+        }
+        guard enteredOperand != String(Double.nan) else {
             return
         }
         if enteredOperand.removeLast() == "." {
@@ -90,6 +94,7 @@ class ViewController: UIViewController {
             enteredOperand += "0"
         }
         calculationFormula += enteredOperator + enteredOperand
+        addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         operatorLabel.text = `operator`
         operandLabel.text = "0"
         isDecimal = false
@@ -109,5 +114,21 @@ class ViewController: UIViewController {
         calculationFormula = "+"
     }
 
+    private func addFormulaStackView(`operator`: String, operand: String) {
+        let formulaStackView = UIStackView()
+        let enteredOperatorLabel = UILabel()
+        let enteredOperandLabel = UILabel()
+
+        enteredOperandLabel.text = operand
+        enteredOperatorLabel.text = `operator`
+        enteredOperandLabel.textColor = .white
+        enteredOperatorLabel.textColor = .white
+        formulaStackView.axis = .horizontal
+        formulaStackView.spacing = 8
+        formulaStackView.addArrangedSubview(enteredOperatorLabel)
+        formulaStackView.addArrangedSubview(enteredOperandLabel)
+
+        formulaStackViews.addArrangedSubview(formulaStackView)
+    }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,10 +7,10 @@
 import UIKit
 
 class ViewController: UIViewController {
-    var calculationFormula: String = "+"
-    var isDecimal: Bool = false
-    var isCalculated: Bool = false
-    var enteredOperand: String = "0"
+    private var calculationFormula: String = "+"
+    private var isDecimal: Bool = false
+    private var isCalculated: Bool = false
+    private var enteredOperand: String = "0"
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -38,6 +38,17 @@ class ViewController: UIViewController {
         operandLabel.text = enteredOperand
     }
 
+    @IBAction func changeSign(_ sender: UIButton) {
+        guard let enteredOperand = operandLabel.text, enteredOperand != "0" else {
+            return
+        }
+        if enteredOperand.first == "-" {
+            operandLabel.text?.removeFirst()
+        } else {
+            operandLabel.text = "-" + enteredOperand
+        }
+    }
+
     @IBAction func addDecimalPoint(_ sender: UIButton) {
         guard let enteredOperand = operandLabel.text, isDecimal == false else {
             return

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -25,6 +25,8 @@ class ViewController: UIViewController {
         operatorLabel.text = ""
         isDecimal = false
         calculationFormula = "+"
+
+        formulaStackViews.removeAllArrangedSubviews()
     }
 
     @IBAction func clearEntry(_ sender: UIButton) {
@@ -109,7 +111,13 @@ class ViewController: UIViewController {
         operatorLabel.text = ""
         isDecimal = false
         var formula = ExpressionParser.parse(from: calculationFormula)
-        operandLabel.text = String(formula.result())
+        var resultValue = String(formula.result())
+        if resultValue.hasSuffix(".0") {
+            resultValue.removeLast()
+            resultValue.removeLast()
+        }
+        operandLabel.text = resultValue
+        addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
 
         calculationFormula = "+"
     }
@@ -132,3 +140,11 @@ class ViewController: UIViewController {
     }
 }
 
+extension UIStackView {
+    func removeAllArrangedSubviews() {
+        arrangedSubviews.forEach {
+            self.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+    }
+}

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -14,41 +14,28 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
+    @IBOutlet weak var operatorLabel: UILabel!
+    @IBOutlet weak var operandLabel: UILabel!
+
+
     @IBAction func addNumber(_ sender: UIButton) {
-        guard let number = sender.currentTitle else {
+        guard let number = sender.currentTitle, let enteredOperand = operandLabel.text else {
             return
         }
-        guard !isOperator() || (number != "0" && number != "00") else {
+        guard enteredOperand != "0" || (number != "0" && number != "00") else {
             return
         }
-        calculationFormula += number
+        if enteredOperand == "0" {
+            operandLabel.text = number
+        } else {
+            operandLabel.text = enteredOperand + number
+        }
     }
 
     @IBAction func addOperator(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle else {
             return
         }
-        guard isNumber() else {
-            return
-        }
-    }
-
-    func isOperator() -> Bool {
-        var result = false
-        for `operator` in Operator.allCases {
-            guard calculationFormula.hasSuffix(String(`operator`.rawValue)) else {
-                continue
-            }
-            result = true
-        }
-        return result
-    }
-
-    func isNumber() -> Bool {
-        guard let lastElement = calculationFormula.last, lastElement.isNumber else {
-            return false
-        }
-        return true
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,7 +8,8 @@ import UIKit
 
 class ViewController: UIViewController {
     var calculationFormula: String = "+"
-    var isDecimal = false
+    var isDecimal: Bool = false
+    var enteredOperand: String = "0"
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,68 +23,67 @@ class ViewController: UIViewController {
 
     @IBAction func allClear(_ sender: UIButton) {
         operandLabel.text?.removeAll()
-        operandLabel.text = "0"
-        operatorLabel.text = ""
         isDecimal = false
+        operatorLabel.text = ""
         calculationFormula = "+"
+        enteredOperand = "0"
+        operandLabel.text = enteredOperand
 
         formulaStackViews.removeAllArrangedSubviews()
     }
 
     @IBAction func clearEntry(_ sender: UIButton) {
-        guard var enteredOperand = operandLabel.text, enteredOperand != "0" else {
-            return
-        }
-        guard enteredOperand != String(Double.nan) else {
+        guard enteredOperand != "0", enteredOperand != String(Double.nan) else {
             return
         }
         if enteredOperand.removeLast() == "." {
             isDecimal = false
         }
-        guard enteredOperand.isEmpty == false else {
-            operandLabel.text = "0"
-            return
+        if enteredOperand.isEmpty {
+            enteredOperand = "0"
         }
         operandLabel.text = enteredOperand
     }
 
     @IBAction func changeSign(_ sender: UIButton) {
-        guard let enteredOperand = operandLabel.text, enteredOperand != "0" else {
+        guard enteredOperand != "0" else {
             return
         }
         if enteredOperand.first == "-" {
-            operandLabel.text?.removeFirst()
+            enteredOperand.removeFirst()
         } else {
-            operandLabel.text = "-" + enteredOperand
+            enteredOperand = "-" + enteredOperand
         }
+        operandLabel.text = enteredOperand
     }
 
     @IBAction func addDecimalPoint(_ sender: UIButton) {
-        guard let enteredOperand = operandLabel.text, isDecimal == false else {
+        guard isDecimal == false else {
             return
         }
-        operandLabel.text = enteredOperand + "."
+        enteredOperand += "."
         isDecimal = true
+        operandLabel.text = enteredOperand
     }
 
     @IBAction func addNumber(_ sender: UIButton) {
-        guard let number = sender.currentTitle, let enteredOperand = operandLabel.text else {
+        guard let number = sender.currentTitle else {
             return
         }
         guard enteredOperand != "0" || (number != "0" && number != "00") else {
             return
         }
         if enteredOperand == "0" {
-            operandLabel.text = number
+            enteredOperand = number
         } else {
-            operandLabel.text = enteredOperand + number
+            enteredOperand += number
         }
+        operandLabel.text = enteredOperand
     }
 
     @IBAction func addOperator(_ sender: UIButton) {
         guard let `operator` = sender.currentTitle,
-              let enteredOperator = operatorLabel.text,
-              var enteredOperand = operandLabel.text else {
+              let enteredOperator = operatorLabel.text else {
             return
         }
         guard enteredOperand != "0" else {
@@ -99,14 +99,14 @@ class ViewController: UIViewController {
         calculationFormula += enteredOperator + enteredOperand
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         operatorLabel.text = `operator`
-        operandLabel.text = "0"
+        enteredOperand = "0"
+        operandLabel.text = enteredOperand
         isDecimal = false
         scrollView.contentOffset.y = scrollView.contentSize.height
     }
 
     @IBAction func calculateResult(_ sender: UIButton) {
-        guard let enteredOperator = operatorLabel.text,
-              let enteredOperand = operandLabel.text else {
+        guard let enteredOperator = operatorLabel.text else {
             return
         }
         calculationFormula += enteredOperator + enteredOperand
@@ -118,7 +118,8 @@ class ViewController: UIViewController {
             resultValue.removeLast()
             resultValue.removeLast()
         }
-        operandLabel.text = resultValue
+        enteredOperand = resultValue
+        operandLabel.text = enteredOperand
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
 
         calculationFormula = "+"

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -18,6 +18,20 @@ class ViewController: UIViewController {
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var operandLabel: UILabel!
 
+    @IBAction func clearEntry(_ sender: UIButton) {
+        guard var enteredOperand = operandLabel.text, enteredOperand != "0" else {
+            return
+        }
+        if enteredOperand.removeLast() == "." {
+            isDecimal = false
+        }
+        guard enteredOperand.isEmpty == false else {
+            operandLabel.text = "0"
+            return
+        }
+        operandLabel.text = enteredOperand
+    }
+
     @IBAction func addDecimalPoint(_ sender: UIButton) {
         guard let enteredOperand = operandLabel.text, isDecimal == false else {
             return

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -18,6 +18,12 @@ class ViewController: UIViewController {
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var operandLabel: UILabel!
 
+    @IBAction func allClear(_ sender: UIButton) {
+        operandLabel.text?.removeAll()
+        operandLabel.text = "0"
+        isDecimal = false
+    }
+
     @IBAction func clearEntry(_ sender: UIButton) {
         guard var enteredOperand = operandLabel.text, enteredOperand != "0" else {
             return

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
+    @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var operandLabel: UILabel!
     @IBOutlet weak var formulaStackViews: UIStackView!
@@ -100,11 +101,12 @@ class ViewController: UIViewController {
         operatorLabel.text = `operator`
         operandLabel.text = "0"
         isDecimal = false
+        scrollView.contentOffset.y = scrollView.contentSize.height
     }
 
     @IBAction func calculateResult(_ sender: UIButton) {
         guard let enteredOperator = operatorLabel.text,
-              var enteredOperand = operandLabel.text else {
+              let enteredOperand = operandLabel.text else {
             return
         }
         calculationFormula += enteredOperator + enteredOperand
@@ -120,6 +122,7 @@ class ViewController: UIViewController {
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
 
         calculationFormula = "+"
+        scrollView.contentOffset.y = scrollView.contentSize.height
     }
 
     private func addFormulaStackView(`operator`: String, operand: String) {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -118,10 +118,9 @@ class ViewController: UIViewController {
             resultValue.removeLast()
             resultValue.removeLast()
         }
+        addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
         enteredOperand = resultValue
         operandLabel.text = enteredOperand
-        addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
-
         calculationFormula = "+"
         scrollView.contentOffset.y = scrollView.contentSize.height
     }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -28,7 +28,6 @@ class ViewController: UIViewController {
         calculationFormula = "+"
         enteredOperand = "0"
         operandLabel.text = formattingNumber(enteredOperand)
-
         formulaStackViews.removeAllArrangedSubviews()
     }
 
@@ -118,9 +117,8 @@ class ViewController: UIViewController {
         isDecimal = false
         isCalculated = true
         var formula = ExpressionParser.parse(from: calculationFormula)
-        let resultValue = String(formula.result())
         addFormulaStackView(operator: enteredOperator, operand: enteredOperand)
-        enteredOperand = resultValue
+        enteredOperand = String(formula.result())
         operandLabel.text = formattingNumber(enteredOperand)
         calculationFormula = "+"
         scrollView.contentOffset.y = scrollView.contentSize.height

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 
 class ViewController: UIViewController {
     var calculationFormula: String = "+"
+    var isDecimal = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -17,6 +18,13 @@ class ViewController: UIViewController {
     @IBOutlet weak var operatorLabel: UILabel!
     @IBOutlet weak var operandLabel: UILabel!
 
+    @IBAction func addDecimalPoint(_ sender: UIButton) {
+        guard let enteredOperand = operandLabel.text, isDecimal == false else {
+            return
+        }
+        operandLabel.text = enteredOperand + "."
+        isDecimal = true
+    }
 
     @IBAction func addNumber(_ sender: UIButton) {
         guard let number = sender.currentTitle, let enteredOperand = operandLabel.text else {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -72,9 +72,22 @@ class ViewController: UIViewController {
     }
 
     @IBAction func addOperator(_ sender: UIButton) {
-        guard let `operator` = sender.currentTitle else {
+        guard let `operator` = sender.currentTitle,
+              let enteredOperator = operatorLabel.text,
+              var enteredOperand = operandLabel.text else {
             return
         }
+        guard enteredOperand != "0" else {
+            operatorLabel.text = `operator`
+            return
+        }
+        if enteredOperand.hasSuffix(".") {
+            enteredOperand += "0"
+        }
+        calculationFormula += enteredOperator + enteredOperand
+        operatorLabel.text = `operator`
+        operandLabel.text = "0"
+        isDecimal = false
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
         operandLabel.text = formattingNumber(enteredOperand) + "."
     }
 
-    @IBAction func addNumber(_ sender: UIButton) {
+    @IBAction func addOperand(_ sender: UIButton) {
         guard let number = sender.currentTitle else {
             return
         }

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -7,8 +7,8 @@
 import UIKit
 
 class ViewController: UIViewController {
-
     var calculationFormula: String = "+"
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -18,8 +18,12 @@ class ViewController: UIViewController {
         guard let number = sender.currentTitle else {
             return
         }
-        print(isOperator())
+        guard !isOperator() || (number != "0" && number != "00") else {
+            return
+        }
+        calculationFormula += number
     }
+
     func isOperator() -> Bool {
         var result = false
         for `operator` in Operator.allCases {

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -61,8 +61,6 @@ class ViewController: UIViewController {
         guard isDecimal == false else {
             return
         }
-        // 테스트 1
-        print(enteredOperand)
         enteredOperand += "."
         isDecimal = true
         guard let formattedNumber = formattingNumber(enteredOperand) else {
@@ -83,7 +81,7 @@ class ViewController: UIViewController {
         } else {
             enteredOperand += number
         }
-        operandLabel.text = formattingNumber(enteredOperand)
+        operandLabel.text = convertOperand(enteredOperand)
     }
 
     @IBAction func addOperator(_ sender: UIButton) {
@@ -152,6 +150,27 @@ class ViewController: UIViewController {
         formatter.maximumFractionDigits = 20
         formatter.numberStyle = .decimal
         return formatter.string(for: Double(number))
+    }
+
+    private func convertOperand(_ operand: String) -> String {
+        if let indexOfPoint = operand.firstIndex(of: ".") {
+            let integerOfOperand = String(operand[operand.startIndex..<indexOfPoint])
+            var decimalOfOperand: String
+            guard let formattedIntegerOfOperand = formattingNumber(integerOfOperand) else {
+                return String()
+            }
+            if operand.distance(from: indexOfPoint, to: operand.endIndex) > 20 {
+                let twentyIndex = operand.index(indexOfPoint, offsetBy: 20)
+                decimalOfOperand = String(operand[indexOfPoint...twentyIndex])
+            } else {
+                decimalOfOperand = String(operand[indexOfPoint..<operand.endIndex])
+            }
+            return String(formattedIntegerOfOperand) + decimalOfOperand
+        }
+        guard let formattedIntegerOfOperand = formattingNumber(operand) else {
+            return String()
+        }
+        return formattedIntegerOfOperand
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -59,15 +59,12 @@ class ViewController: UIViewController {
     }
 
     @IBAction func addDecimalPoint(_ sender: UIButton) {
-        guard isDecimal == false else {
+        guard isDecimal == false, isCalculated == false else {
             return
         }
         enteredOperand += "."
         isDecimal = true
-        guard let formattedNumber = formattingNumber(enteredOperand) else {
-            return
-        }
-        operandLabel.text = formattedNumber + "."
+        operandLabel.text = formattingNumber(enteredOperand) + "."
     }
 
     @IBAction func addNumber(_ sender: UIButton) {
@@ -147,32 +144,26 @@ class ViewController: UIViewController {
         formulaStackViews.addArrangedSubview(formulaStackView)
     }
 
-    private func formattingNumber(_ number: String) -> String? {
+    private func formattingNumber(_ number: String) -> String {
         let formatter = NumberFormatter()
         formatter.maximumFractionDigits = 20
         formatter.numberStyle = .decimal
-        return formatter.string(for: Double(number))
+        return formatter.string(for: Double(number)) ?? number
     }
 
     private func convertOperand(_ operand: String) -> String {
         if let indexOfPoint = operand.firstIndex(of: ".") {
             let integerOfOperand = String(operand[operand.startIndex..<indexOfPoint])
             var decimalOfOperand: String
-            guard let formattedIntegerOfOperand = formattingNumber(integerOfOperand) else {
-                return String()
-            }
             if operand.distance(from: indexOfPoint, to: operand.endIndex) > 20 {
                 let twentyIndex = operand.index(indexOfPoint, offsetBy: 20)
                 decimalOfOperand = String(operand[indexOfPoint...twentyIndex])
             } else {
                 decimalOfOperand = String(operand[indexOfPoint..<operand.endIndex])
             }
-            return String(formattedIntegerOfOperand) + decimalOfOperand
+            return formattingNumber(integerOfOperand) + decimalOfOperand
         }
-        guard let formattedIntegerOfOperand = formattingNumber(operand) else {
-            return String()
-        }
-        return formattedIntegerOfOperand
+        return formattingNumber(operand)
     }
 }
 

--- a/Calculator/Calculator/Controller/ViewController.swift
+++ b/Calculator/Calculator/Controller/ViewController.swift
@@ -11,6 +11,7 @@ class ViewController: UIViewController {
     private var isDecimal: Bool = false
     private var isCalculated: Bool = false
     private var enteredOperand: String = "0"
+    private let point = "."
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,7 +36,7 @@ class ViewController: UIViewController {
         guard isInitialOperand() == false, enteredOperand != String(Double.nan), isCalculated == false else {
             return
         }
-        if enteredOperand.removeLast() == "." {
+        if enteredOperand.removeLast() == Character(point) {
             isDecimal = false
         }
         if enteredOperand.isEmpty {
@@ -60,9 +61,9 @@ class ViewController: UIViewController {
         guard isDecimal == false, isCalculated == false else {
             return
         }
-        enteredOperand += "."
+        enteredOperand += point
         isDecimal = true
-        operandLabel.text = formattingNumber(enteredOperand) + "."
+        operandLabel.text = formattingNumber(enteredOperand) + point
     }
 
     @IBAction func addOperand(_ sender: UIButton) {
@@ -96,7 +97,7 @@ class ViewController: UIViewController {
             operatorLabel.text = `operator`
             return
         }
-        if enteredOperand.hasSuffix(".") {
+        if enteredOperand.hasSuffix(point) {
             enteredOperand += "0"
         }
         calculationFormula += enteredOperator + enteredOperand
@@ -149,7 +150,7 @@ class ViewController: UIViewController {
     }
 
     private func convertOperand(_ operand: String) -> String {
-        if let indexOfPoint = operand.firstIndex(of: ".") {
+        if let indexOfPoint = operand.firstIndex(of: Character(point)) {
             let integerOfOperand = String(operand[operand.startIndex..<indexOfPoint])
             var decimalOfOperand: String
             if operand.distance(from: indexOfPoint, to: operand.endIndex) > 20 {
@@ -165,14 +166,5 @@ class ViewController: UIViewController {
 
     private func isInitialOperand() -> Bool {
         return enteredOperand == "0"
-    }
-}
-
-extension UIStackView {
-    func removeAllArrangedSubviews() {
-        arrangedSubviews.forEach {
-            self.removeArrangedSubview($0)
-            $0.removeFromSuperview()
-        }
     }
 }

--- a/Calculator/Calculator/Model/CalculateItem.swift
+++ b/Calculator/Calculator/Model/CalculateItem.swift
@@ -13,9 +13,9 @@ protocol CalculateItem {
 
 enum Operator: Character, CalculateItem, CaseIterable {
     case add = "+"
-    case subtract = "-"
-    case divide = "/"
-    case multiply = "*"
+    case subtract = "−"
+    case divide = "÷"
+    case multiply = "×"
 
     func calculate(lhs: Double, rhs: Double) -> Double {
         switch self {

--- a/Calculator/Calculator/Model/UIStackView+Extension.swift
+++ b/Calculator/Calculator/Model/UIStackView+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  UIStackView+Extension.swift
+//  Calculator
+//
+//  Created by 박재우 on 2023/02/02.
+//
+
+import UIKit
+
+extension UIStackView {
+    func removeAllArrangedSubviews() {
+        arrangedSubviews.forEach {
+            self.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+    }
+}

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -107,6 +107,9 @@
                                                 <state key="normal" title="⁺⁄₋">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="changeSign:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LCY-iO-QQK"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tfz-eM-jll">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -109,6 +109,9 @@
                                                 <state key="normal" title="÷">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addOperator:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uOK-X6-buv"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -155,6 +158,9 @@
                                                 <state key="normal" title="×">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addOperator:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kFi-jL-zlZ"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -201,6 +207,9 @@
                                                 <state key="normal" title="−">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addOperator:" destination="BYZ-38-t0r" eventType="touchUpInside" id="I6q-kf-FpG"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>
@@ -247,6 +256,9 @@
                                                 <state key="normal" title="+">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addOperator:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IQ6-30-ISU"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -93,6 +93,9 @@
                                                 <state key="normal" title="CE">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="clearEntry:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dT6-tb-ldA"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ows-U7-mNc">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -295,7 +298,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addDecimal:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dLV-yl-Fs9"/>
+                                                    <action selector="addDecimalPoint:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2IY-ER-7wD"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -112,7 +112,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9BR-WL-9Ht"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9BR-WL-9Ht"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
@@ -123,7 +123,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1eY-By-CUf"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1eY-By-CUf"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
@@ -134,7 +134,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58m-NW-i4X"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58m-NW-i4X"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
@@ -161,7 +161,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hJO-Pt-HzM"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hJO-Pt-HzM"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
@@ -172,7 +172,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4My-kK-oyk"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4My-kK-oyk"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
@@ -183,7 +183,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9ka-LG-vsY"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9ka-LG-vsY"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
@@ -210,7 +210,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gvB-qA-tcP"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gvB-qA-tcP"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
@@ -221,7 +221,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CZP-9H-UBZ"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CZP-9H-UBZ"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
@@ -232,7 +232,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58q-AJ-dSO"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58q-AJ-dSO"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
@@ -259,7 +259,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pLs-fM-iVQ"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pLs-fM-iVQ"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
@@ -270,7 +270,7 @@
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <connections>
-                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iSv-NE-sxT"/>
+                                                    <action selector="addOperand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iSv-NE-sxT"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -85,6 +85,9 @@
                                                 <state key="normal" title="AC">
                                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="allClear:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fcF-tS-1RA"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RLD-dY-LOA">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="229.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="220.5" width="382" height="52"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
@@ -311,19 +311,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DC3-Ia-6L7">
-                                <rect key="frame" x="16" y="301.5" width="382" height="41"/>
+                                <rect key="frame" x="16" y="292.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2pK-nQ-lxl">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="41"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
-                                                <rect key="frame" x="0.0" y="0.0" width="21" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HPC-iy-qdm">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
-                                                <rect key="frame" x="29" y="0.0" width="353" height="41"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lwz-OF-XHD">
+                                                <rect key="frame" x="58" y="0.0" width="324" height="50"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -348,6 +348,10 @@
                             <constraint firstItem="DC3-Ia-6L7" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="vTI-88-p1o"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="operandLabel" destination="Lwz-OF-XHD" id="X0a-d0-0Kr"/>
+                        <outlet property="operatorLabel" destination="HPC-iy-qdm" id="ypJ-tY-YUD"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -121,6 +122,9 @@
                                                 <state key="normal" title="7">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9BR-WL-9Ht"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgT-2D-A49">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -129,6 +133,9 @@
                                                 <state key="normal" title="8">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1eY-By-CUf"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zcj-xJ-ruw">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -137,6 +144,9 @@
                                                 <state key="normal" title="9">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58m-NW-i4X"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="811-Pz-An6">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -158,6 +168,9 @@
                                                 <state key="normal" title="4">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hJO-Pt-HzM"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vpW-df-OLm">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -166,6 +179,9 @@
                                                 <state key="normal" title="5">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4My-kK-oyk"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OaY-Mw-CPv">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -174,6 +190,9 @@
                                                 <state key="normal" title="6">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="9ka-LG-vsY"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nTe-Sn-Pvd">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -195,6 +214,9 @@
                                                 <state key="normal" title="1">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gvB-qA-tcP"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-2S-UU2">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -203,6 +225,9 @@
                                                 <state key="normal" title="2">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CZP-9H-UBZ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X8H-iH-tSd">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>
@@ -211,6 +236,9 @@
                                                 <state key="normal" title="3">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="58q-AJ-dSO"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sbh-wC-koF">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>
@@ -232,6 +260,9 @@
                                                 <state key="normal" title="0">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="pLs-fM-iVQ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sH6-8l-kje">
                                                 <rect key="frame" x="97.5" y="0.0" width="89.5" height="89.5"/>
@@ -240,6 +271,9 @@
                                                 <state key="normal" title="00">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addNumber:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iSv-NE-sxT"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8q-5h-bnb">
                                                 <rect key="frame" x="195" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -18,39 +18,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BOT-7g-vxv">
-                                <rect key="frame" x="16" y="220.5" width="382" height="52"/>
+                                <rect key="frame" x="16" y="222.5" width="382" height="50"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XRe-QE-UJf">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="50"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2Pu-Ld-ZGi">
-                                                <rect key="frame" x="249.5" y="0.0" width="132.5" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c7v-6K-W40">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oGo-LN-bKL">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6I9-iL-eIa">
-                                                <rect key="frame" x="249.5" y="28" width="132.5" height="24"/>
+                                                <rect key="frame" x="332" y="0.0" width="50" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="9" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1234567890" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hcb-r0-27f">
-                                                        <rect key="frame" x="17" y="0.0" width="115.5" height="24"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alw-Zd-2pT">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
@@ -364,6 +341,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="formulaStackViews" destination="XRe-QE-UJf" id="Vuu-Xr-7Gh"/>
                         <outlet property="operandLabel" destination="Lwz-OF-XHD" id="X0a-d0-0Kr"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="ypJ-tY-YUD"/>
                     </connections>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -344,6 +344,7 @@
                         <outlet property="formulaStackViews" destination="XRe-QE-UJf" id="Vuu-Xr-7Gh"/>
                         <outlet property="operandLabel" destination="Lwz-OF-XHD" id="X0a-d0-0Kr"/>
                         <outlet property="operatorLabel" destination="HPC-iy-qdm" id="ypJ-tY-YUD"/>
+                        <outlet property="scrollView" destination="BOT-7g-vxv" id="ZPb-Ll-yBF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -317,6 +317,9 @@
                                                 <state key="normal" title="=">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="calculateResult:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qMu-BL-OOh"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/Calculator/Calculator/View/Base.lproj/Main.storyboard
+++ b/Calculator/Calculator/View/Base.lproj/Main.storyboard
@@ -294,6 +294,9 @@
                                                 <state key="normal" title=".">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="addDecimal:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dLV-yl-Fs9"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Daw-iX-Owl">
                                                 <rect key="frame" x="292.5" y="0.0" width="89.5" height="89.5"/>

--- a/Calculator/QueueTests/ComponentsByOperatorsTests.swift
+++ b/Calculator/QueueTests/ComponentsByOperatorsTests.swift
@@ -9,14 +9,14 @@ import XCTest
 
 final class ComponentsByOperatorsTests: XCTestCase {
     func test_연산자로_split이_되는지_확인() {
-        let input = "1+22-10*3/2+3"
+        let input = "1+22−10×4×3÷2+3"
         let result = ExpressionParser.componentsByOperators(from: input)
-        let expected = ["1","22","10","3","2","3"]
+        let expected = ["1","22","10","4","3","2","3"]
         XCTAssertEqual(result, expected)
     }
 
     func test_extractOperators의_반환값이_정확한지_확인() {
-        let input = "1+22-10*3/2+3"
+        let input = "1+22−10×3÷2+3"
         let result = ExpressionParser.extractOperators(from: input)
         let expected: [Operator] = [.add, .subtract, .multiply, .divide, .add]
         XCTAssertEqual(result, expected)
@@ -33,7 +33,7 @@ final class ComponentsByOperatorsTests: XCTestCase {
     }
 
     func test_result메서드가_올바른_계산이_되는지_확인() {
-        let input = "+1+22-10*3/2+3"
+        let input = "+1+22−10×3÷2+3"
         var fomula = ExpressionParser.parse(from: input)
         let result = fomula.result()
         let expected: Double = 22.5

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# iOS_calculator README 작성 (Joo & Lust3r)
+# iOS_calculator README (Joo & Lust3r)
 ----
-
+## 🧮 계산기 동작
+<img width="45%" src="https://user-images.githubusercontent.com/79438622/215037745-d677bb79-b64b-47f4-9226-e5c1bad003c8.gif">
+<span>  </span>
+<img width="45%" src="https://user-images.githubusercontent.com/79438622/215037774-a71cc81e-dcdb-4c76-b11c-a6f16c949a7b.gif">
 ## 🗂️ 프로젝트 파일 구조
 ![188132535-8bc81913-7863-4877-88f9-0f8e811a52bd](https://user-images.githubusercontent.com/45708630/213386825-29d5bd14-4f73-49e0-9862-4d5939af10cb.jpeg)
+
 ---
 ## 🕵🏻 역할 분배
 |enum|역할|
@@ -23,6 +27,20 @@
 |:---|:---|
 |Operator|연산자를 열거형으로 정의. calculate 메서드에서 private 타입의 add, substract, divide, multiply 메서드를 사용할 수 있도록 구현. 은닉화된 연산 메서드들은 이름과 동일한 계산해서 Double값으로 반환|
 |Double|`CalculateItemQueue`의 요소로 사용되도록 `CalculateItem`을 채택|
+
+|function|역할|
+|:---|:---|
+|allClear|입력받았던 내용들을 초기화|
+|clearEntry|입력받은 숫자 혹은 소수점을 제거</br>(단, 결과값은 삭제 불가)|
+|changeSign|입력받은 숫자의 부호를 변경, 음수라면 양수로 변환을 하고 양수라면 음수로 변환|
+|addDecimalPoint|입력받은 숫자의 소수점을 부여</br>(단, 이미 입력받았다면 입력 불가)|
+|addOperand|계산하고자 하는 숫자를 입력|
+|addOperator|계산하고자 하는 연산자를 입력, 숫자를 입력받은 상태가 아니라면 기존의 연산자를 변경|
+|calculateResult|계산을 하고자 추가한 식들을 계산하여 반환|
+|addFormulaStackView|입력된 `operand`와 `operator`로 `UILabel`을 생성하고, Stack에 `addArrangedSubView`를 통해 담은 후 `ScrollView`에서 볼 수 있도록 추가 |
+|formattingNumber|`NumberFormatter()`를 사용하기 위한 함수로, formatter 설정을 통해 소수점 자리수 20, `numberStyle = .decimal`을 통해 천단위 구분 표시를 할 수 있도록 함|
+|convertOperand|정수부를 천단위 구분 표시 하면서 소수부가 '0'이나 '00'이어도 같이 화면에 보일 수 있도록 operand를 정수부와 소수부로 나누어 정수부는 Formatting 진행, 소수부는 그 결과에 덧붙이는 식으로 operand를 convert|
+|isInitialOperand|enteredOperand가 초기값인 '0'인지 확인|
 
 ---
 
@@ -46,12 +64,14 @@
 
 ---
    
-## 🧨 트러블 슈팅
-1. **[Step 1]** 유닛테스트 시 `XCTAssertEqual`을 사용할 때 오류가 발생하여 queue에 들어가는 Item에 `Equatable` 프로토콜을 채택하여 해결하였습니다
-2. **[Step 1]** Unit Test를 진행하면서 dequeue를 사용하면 `isEmpty`가 false인 상황에서는 문제가 되지 않지만 true일 때는 warning이 발생하여 @discardableResult를 사용하여 해결하였습니다.
-3. **[Step 2]** UML에서 요구한 split에서는 Character를 target으로 하기에는 원하는 결과가 나오지 않아 `components(separatedBy: CharacterSet)`를 사용하여 구분자에 맞춰 문자열로 반환하였습니다.
-   
+## Step3 - 계산기 UI 연동
+[PR 대기 | Step3 ]()
+
+### 구현 내용
+- 사용자의 터치 이벤트를 수신하여 그 이벤트로 발생하는 숫자와 연산자의 연산 결과를 내기 위해 각 버튼을 연결하고, 터치 이벤트 수신시 실행할 기능을 작성하였습니다.</br>입력된 내용은 결과값 위쪽 공간에 스크롤이 가능하도록 stack처리하였고, 그 내역이 상단 공간을 넘어 이어지는 경우에는 스크롤이 하단으로 자동으로 이동하여 최근 내역을 볼 수 있도록 하였습니다.
+
 ---
+
    
 ## 📓 학습내용 요점
 ### 1. generic function
@@ -95,34 +115,49 @@ let doubleArray= splittedStringArray.compactMap { Double($0) }
 검색 작업에 사용할 유니코드 문자 값 세트. 본 프로젝트에서는 String 내에서 Operator Character를 CharacterSet으로 만들어 검색작업을 진행했습니다.
 ```swift
 static func componentsByOperators(from input: String) -> [String] {
-        let operators: String = String(Operator.allCases.map { $0.rawValue })
-        let operatorSet: CharacterSet = CharacterSet(charactersIn: operators)
-        return input.components(separatedBy: operatorSet)
-    }
+    let operators: String = String(Operator.allCases.map { $0.rawValue })
+    let operatorSet: CharacterSet = CharacterSet(charactersIn: operators)
+    return input.components(separatedBy: operatorSet)
+}
 ```
 > 참고 : [공식 문서](https://developer.apple.com/documentation/foundation/characterset)
 
+### 5. UIScrollView / UIStackView
+스크롤 뷰 구조를 보니 연산내역이 담긴 스택들을 담은 스택이 있는 구조여서
+(ScrollView > StackView > StackView/StackView)
+그 구조에 맞게 연산자와 숫자를 담을 Label을 생성한 후, StackView에 담아 연산내역이 담긴 스택들을 담은 스택에 추가하는 방식을 사용했습니다.
+```Swift
+private func addFormulaStackView(`operator`: String, operand: String) {
+    let formulaStackView = UIStackView()
+    let enteredOperatorLabel = UILabel()
+    let enteredOperandLabel = UILabel()
+    //...
+    formulaStackView.addArrangedSubview(enteredOperatorLabel)
+    formulaStackView.addArrangedSubview(enteredOperandLabel)
+
+    formulaStackViews.addArrangedSubview(formulaStackView)
+}
+```
+> 참고 1 : [공식 문서](https://developer.apple.com/documentation/uikit/uiscrollview)
+> 참고 2 : [공식 문서](https://developer.apple.com/documentation/uikit/uistackview)
+
+### 6. NumberFormatter
+소수점 아래 20자리 표시, 정수부 천단위 표시를 위해 `NumberFormatter`를 이용하였습니다.
+`numberStyle = .decimal`을 통해 천단위 표시를 할 수 있었고, `maximumFractionDigits = 20`을 통해 최대 소수점 자리를 20으로 설정할 수 있었습니다.
+``` Swift
+private func formattingNumber(_ number: String) -> String {
+    let formatter = NumberFormatter()
+    formatter.maximumFractionDigits = 20
+    formatter.numberStyle = .decimal
+    return formatter.string(for: Double(number)) ?? number
+}
+```
+> 참고 : [공식 문서](https://developer.apple.com/documentation/foundation/numberformatter)
+
 ---
 
-## 🔖 프로젝트 계획
-### STEP3 에서 적용해야 하는 부분
-
-- 계산의 처음 숫자의 연산자는 default는 `.add` 이다
-(macOS 기본 계산기에서도 숫자 버튼 누르기 전에 연산자를 변경 가능)
-- 계산기의 순서는 아래와 같다
-    1. 연사자를 입력 (첫 숫자 입력의 연산자는 `.add`)
-    2. 숫자를 입력
-    3. 1 ~ 2번의 행동을 반복하게 된다
-- `+ / -`는 String으로 입력받는 형태(`sign`)에서 기호로 받는다
-    
-    ```swift
-    // ➕, ➖: 이모지로 positive와 negative를 판단하도록 분리
-    "+15➕*10➕-17➖"
-    ```
-- parse 부분에서 `sign`을 구분짓고 새로운 Queue를 만들어야 한다
-- `.`의 입력을 받았다면 1번만 받도록 enum으로?? 관리한다
-- `sign`과 `.` 을 계산기의 순서에서 새로운 연산자를 받을 때마다 초기화를 한다
-(`.`은 unused, used로 구분 / `sign`은  positive, negative로 구분)
-- 그 외에 예외 사항은 STEP3에서 입력받을 때 처리를 해야한다 판단한다
-
----
+## 🧨 트러블 슈팅
+1. **[Step 1]** 유닛테스트 시 `XCTAssertEqual`을 사용할 때 오류가 발생하여 queue에 들어가는 Item에 `Equatable` 프로토콜을 채택하여 해결하였습니다
+2. **[Step 1]** Unit Test를 진행하면서 dequeue를 사용하면 `isEmpty`가 false인 상황에서는 문제가 되지 않지만 true일 때는 warning이 발생하여 @discardableResult를 사용하여 해결하였습니다.
+3. **[Step 2]** UML에서 요구한 split에서는 Character를 target으로 하기에는 원하는 결과가 나오지 않아 `components(separatedBy: CharacterSet)`를 사용하여 구분자에 맞춰 문자열로 반환하였습니다.
+4. **[Step 3]** AC의 버튼의 경우, scrollView내에 존재하는 subViews의 객체들을 삭제하기 위해서 `removeArrangedSubview`을 사용하였으나 삭제되지 않았습니다. 해결하기 위해서 `removeFromSuperview`도 사용을 하여서 내부에 존재하는 subViews를 삭제하였습니다.


### PR DESCRIPTION
안녕하세요! 소대(@zdodev)! 이번 Calculator 프로젝트를 진행하게 된 Joo, Lust3r 입니다!
Step 2에서 구현한 틀을 바탕으로 Step 3에서 세부 내용을 구현해 보았습니다.

프로젝트 진행에 있어 문의사항이 있을 때 바로 확인해주시고, 2주간 PR 리뷰 해주셔서 감사합니다!🙌🏻


## 🧑🏼‍💻 작업 목록

### STEP 3 : [ 스크럼 ](https://www.notion.so/tastycode/003ce70117fb41b98f42a7d715a54ce1?v=ad62c99696834207b6e5b441c49fcc9e)

- [x] 사용자의 터치 이벤트 수신
- [x] 숫자 입력 및 계산 기능 구현
- [x] 계산 내역 표시
- [x] 내역 길이에 따라 스크롤 기능 구현
- [x] 계산내역 추가시 스크롤이 하단에 위치하도록 구현
- [x] 천단위 구분자 표시

## 💭 학습 키워드

- IBOutlet
- IBAction
- StackView
- ScrollView
- NumberFormatter

## 🤔 고민과 해결
- 계산 작업이 다양하다보니 예외처리가 많아 어떻게 하면 잘 정리할 수 있을지 고민했습니다.</br> 고민 끝에 `isDecimal`,`isCalculated` 변수를 통해 특정 상황을 통제하고, if/guard문으로 해결할 수 있었습니다.
- ± 버튼을 어떻게 반영해야 할지에 대한 고민을 했었습니다. 최종적으로 입력된 값의 앞 부호가 음수면 제거하고, 양수라면 음수 기호를 추가하는 방식으로 구현했습니다.
- 스크롤 뷰 내에 계산한 내용을 추가하는데 어려움이 있어 다양한 자료를 찾아보았습니다. 이후 `UIStackView`와 `UILabel`을 생성하는 함수(`addFormulaStackView`)를 만들고, `UIStackView` 안에 `UILabel`을 담은 후 기존 계산내역을 담고 있던 `StackView`에 올리는 방법으로 해결하였습니다.
![](https://i.imgur.com/xbw3FuM.png)
- 천단위 구분자 표시를 위해서 numberFormatter 사용을 했으나 23.00 의 경우 23으로 변환을 하기에 해결을 위해서 정수부와 소수부로 나누고 정수부에서만 numberFormatter 적용을 하였습니다.


## 🙋🏻 질문 거리
- scrollView에서 stackView 혹은 UILabel의 경우에는 이미 설정되어 있는 제약을 따르지만 UIView를 여러 개 넣었을 때에는 제약을 따르지 않고 겹쳐서 보였습니다. subView에 UIView를 넣기 위해서는 무엇을 해야되는 지 궁금합니다.</br>subView 내에 UIView가 들어가는 게 일반적이지 않다면 어떤 Object가 들어가는지 궁금합니다. 
- 사용된 코드 중에서 아래와 같은 코드를 사용하였는데, guard문을 사용할 때 조건들은 몇 개가 적당한지 궁금하고 복잡하다 생각되는 부분은 Bool값으로 반환하는 함수를 만드는 게 나은 건지 궁금합니다
    ``` Swift
    guard isInitialOperand() == false || (number != "0" && number != "00") else {
        return
    }
    ```
    만약 함수로 만든다면 isZero(number: String) -> Bool과 같이 만들려고 했습니다
- 정수부와 소수부를 나누어서 각각 처리를 하였습니다. 하지만 Swift에서는 String을 Index로 길이를 확인하거나 검색하는 과정이 단순하지 않았는데, Array로 변환해서 처리를 하고 String으로 변환하는 게 더 나은가요? 
- 위의 질문에 덧붙여, numberFormatter 적용을 해보니 *. 의 상황에서 0이나 00을 입력하면 뒷부분이 없이 앞의 정수부분만 보여주기에 정수부와 소수부를 나누고 정수부에만 Formatter 적용을 했습니다. 이처럼 각 부분을 나누지 않고 Formatter를 한 번 사용하여 .0과 .00도 표현할 수 있는 방법이 있을까요?